### PR TITLE
Type Difference w/o Function

### DIFF
--- a/typediff/without-function/CoherenceTop.v
+++ b/typediff/without-function/CoherenceTop.v
@@ -4,12 +4,16 @@ Require Import Coq.Structures.Equalities.
 Require Import Coq.MSets.MSetInterface.
 Require Import Arith.
 Require Import Setoid.
+Require Import Coq.Program.Wf.
+Require Import Coq.omega.Omega.
+Require Import Coq.Program.Equality.
 
-Module CoherenceTop
+
+Module CoherenceTopModule
        (Import VarTyp : UsualDecidableTypeFull)
        (Import set : MSetInterface.S).
 
-  
+
 Module ST := TLC(VarTyp)(set).
 Import ST.
 
@@ -20,7 +24,7 @@ The syntax is encoded using Charguéraud's Locally nameless representation:
 
 http://www.chargueraud.org/softs/ln/
 
-We annotate the Coq theorems with the correnposing lemmas/theorems in the paper. 
+We annotate the Coq theorems with the correnposing lemmas/theorems in the paper.
 The reader can just look for:
 
 Lemma 4
@@ -37,50 +41,54 @@ with the exceptions of "tlam" and "tylam" due to a technical limitation.
 
 Inductive PTyp : Type :=
   | PInt : PTyp
-  | Fun : PTyp -> PTyp -> PTyp
   | And : PTyp -> PTyp -> PTyp
   | TopT : PTyp.
+(*  | Fun : PTyp -> PTyp -> PTyp *)
 
 Fixpoint ptyp2styp (t : PTyp) : STyp :=
   match t with
-    | PInt => STInt 
-    | Fun t1 t2 => STFun (ptyp2styp t1) (ptyp2styp t2)
+    | PInt => STInt
+(*    | Fun t1 t2 => STFun (ptyp2styp t1) (ptyp2styp t2)  *)
     | And t1 t2 => STTuple (ptyp2styp t1) (ptyp2styp t2)
     | TopT => STUnitT
   end.
 
 
 Inductive TopLike : PTyp -> Prop :=
-  | TLTop : TopLike TopT
   | TLAnd : forall A B, TopLike A -> TopLike B -> TopLike (And A B)
-  | TLFun : forall A B, TopLike B -> TopLike (Fun A B).
+(*  | TLFun : forall A B, TopLike B -> TopLike (Fun A B).  *)
+  | TLTop : TopLike TopT.
 
 (* Unrestricted Subtyping *)
+(* usub A B : A <: B *)
 
 Inductive usub : PTyp -> PTyp -> Prop :=
   | USInt : usub PInt PInt
-  | USFun : forall o1 o2 o3 o4, usub o3 o1 -> usub o2 o4 -> usub (Fun o1 o2) (Fun  o3 o4) 
-  | USAnd1 : forall t t1 t2, usub t t1 -> usub t t2 -> usub t (And  t1 t2) 
-  | USAnd2 : forall t t1 t2 , usub t1 t -> usub (And t1 t2) t 
-  | USAnd3 : forall t t1 t2, usub t2 t -> usub (And t1 t2) t 
+(*  | USFun : forall o1 o2 o3 o4, usub o3 o1 -> usub o2 o4 -> usub (Fun o1 o2) (Fun  o3 o4) *)
+  | USAnd1 : forall t t1 t2, usub t t1 -> usub t t2 -> usub t (And  t1 t2)
+  | USAnd2 : forall t t1 t2 , usub t1 t -> usub (And t1 t2) t
+  | USAnd3 : forall t t1 t2, usub t2 t -> usub (And t1 t2) t
   | USTop : forall t, usub t TopT.
 
-(* TODO: Show transitivity of usub here, and easily derive transitivity 
+(* TODO: Show transitivity of usub here, and easily derive transitivity
 for sub *)
 
 (* Restricted Subtyping relation *)
 
 Inductive Atomic : PTyp -> Prop :=
-  | AInt : Atomic PInt
-  | AFun : forall t1 t2, Atomic (Fun t1 t2).  
+| AInt : Atomic PInt.
+(*  | AFun : forall t1 t2, Atomic (Fun t1 t2).  *)
 
+Hint Resolve AInt.
+
+(* ? *)
 Fixpoint and_coercion (t : PTyp) (e : Exp) {struct t} : sum Exp Exp :=
   match t with
     | PInt    => inr e
-    | Fun _ B => match (and_coercion B e) with
+(*    | Fun _ B => match (and_coercion B e) with
                   | inl l => inl (fun A : Type => STLam' A (l A))
                   | inr r => inr r
-                 end 
+                 end  *)
     | And A B => match (and_coercion A e, and_coercion B e) with
                   | (inl l1, inl l2) =>
                     inl (fun A : Type => STPair _ (l1 A) (l2 A))
@@ -95,10 +103,10 @@ Defined.
 
 Inductive sub : PTyp -> PTyp -> Exp -> Prop :=
   | SInt : sub PInt PInt (fun A => STLam' _ (STBVar _ 0))
-  | SFun : forall o1 o2 o3 o4 c1 c2, sub o3 o1 c1 -> sub o2 o4 c2 -> 
-     sub (Fun o1 o2) (Fun  o3 o4) (fun A => STLam' _ ( 
-       STLam' _ (STApp _ (c2 A) (STApp _ (STBVar _ 1) (STApp _ (c1 A) (STBVar _ 0))))))
-  | SAnd1 : forall t t1 t2 c1 c2, sub t t1 c1 -> sub t t2 c2 -> 
+(*  | SFun : forall o1 o2 o3 o4 c1 c2, sub o3 o1 c1 -> sub o2 o4 c2 ->
+     sub (Fun o1 o2) (Fun  o3 o4) (fun A => STLam' _ (
+       STLam' _ (STApp _ (c2 A) (STApp _ (STBVar _ 1) (STApp _ (c1 A) (STBVar _ 0))))))  *)
+  | SAnd1 : forall t t1 t2 c1 c2, sub t t1 c1 -> sub t t2 c2 ->
      sub t (And  t1 t2) (fun A => STLam' _ (
        STPair _ (STApp _ (c1 A) (STBVar _ 0)) (STApp _ (c2 A) (STBVar _ 0))))
   | SAnd2 : forall t t1 t2 c, sub t1 t c -> Atomic t ->
@@ -116,7 +124,7 @@ Definition Sub (t1 t2 : PTyp) : Prop := exists (e:Exp), sub t1 t2 e.
 (* Smart constructors for Sub *)
 
 Definition sint : Sub PInt PInt.
-unfold Sub. exists (fun A => STLam' _ (STBVar _ 0)). 
+unfold Sub. exists (fun A => STLam' _ (STBVar _ 0)).
 exact SInt.
 Defined.
 
@@ -125,17 +133,17 @@ intros; unfold Sub.
 exists (fun A => STLam' _ (STUnit _)).
 apply STop.
 Defined.
-
+(*
 Definition sfun : forall o1 o2 o3 o4, Sub o3 o1 -> Sub o2 o4 -> Sub (Fun o1 o2) (Fun  o3 o4).
 unfold Sub; intros. destruct H. destruct H0.
-exists (fun A => STLam' _ ( 
+exists (fun A => STLam' _ (
        STLam' _ (STApp _ (x0 A) (STApp _ (STBVar _ 1) (STApp _ (x A) (STBVar _ 0)))))).
 apply SFun. auto. auto.
 Defined.
-
+*)
 Definition sand1 : forall t t1 t2, Sub t t1 -> Sub t t2 -> Sub t (And t1 t2).
 unfold Sub. intros. destruct H. destruct H0.
-exists (fun A => STLam' _ ( 
+exists (fun A => STLam' _ (
        STPair _ (STApp _ (x A) (STBVar _ 0)) (STApp _ (x0 A) (STBVar _ 0)))).
 apply SAnd1. auto. auto.
 Defined.
@@ -145,9 +153,9 @@ unfold Sub. intro t. intros. destruct t. destruct H.
 exists (fun A => STLam' _ (join_sum (and_coercion PInt (fun A => (
        (STApp _ (x A) (STProj1 _ (STBVar _ 0)))))) A)).
 apply SAnd2. auto. auto. destruct H.
-exists (fun A => STLam' _ (join_sum (and_coercion (Fun t3 t4) (fun A => (
+(* exists (fun A => STLam' _ (join_sum (and_coercion (Fun t3 t4) (fun A => (
        (STApp _ (x A) (STProj1 _ (STBVar _ 0)))))) A)).
-apply SAnd2. auto. auto.
+apply SAnd2. auto. auto. *)
 inversion H0.
 apply stop. (* a top case here *)
 Defined.
@@ -157,11 +165,11 @@ intro t; induction t; intros.
 (* Case PInt *)
 apply sand2_atomic. auto. exact AInt.
 (* Case Fun *)
-apply sand2_atomic. auto. apply AFun.
+(* apply sand2_atomic. auto. apply AFun. *)
 (* Case And *)
 unfold Sub. unfold Sub in H. destruct H. inversion H.
 assert (Sub (And t0 t3) t1). apply IHt1.
-unfold Sub. exists c1. auto. 
+unfold Sub. exists c1. auto.
 assert (Sub (And t0 t3) t2). apply IHt2.
 unfold Sub. exists c2. auto.
 unfold Sub in H6. destruct H6.
@@ -180,9 +188,9 @@ Definition sand3_atomic : forall t t1 t2, Sub t2 t -> Atomic t -> Sub (And  t1 t
   exists (fun A => STLam' _ (join_sum (and_coercion PInt (fun A => (
        (STApp _ (x A) (STProj2 _ (STBVar _ 0)))))) A)).
 apply SAnd3. auto. auto. destruct H.
-exists (fun A => STLam' _ (join_sum (and_coercion (Fun t3 t4) (fun A => (
+(* exists (fun A => STLam' _ (join_sum (and_coercion (Fun t3 t4) (fun A => (
        (STApp _ (x A) (STProj2 _ (STBVar _ 0)))))) A)).
-apply SAnd3. auto. auto.
+apply SAnd3. auto. auto. *)
 inversion H0.
 apply stop. (* a top case here *)
 Defined.
@@ -192,16 +200,16 @@ intro t; induction t; intros.
 (* Case PInt *)
 apply sand3_atomic. auto. exact AInt.
 (* Case Fun *)
-apply sand3_atomic. auto. apply AFun.
+(* apply sand3_atomic. auto. apply AFun. *)
 (* Case And *)
 unfold Sub. unfold Sub in H. destruct H. inversion H.
 assert (Sub (And t0 t3) t1). apply IHt1.
-unfold Sub. exists c1. auto. 
+unfold Sub. exists c1. auto.
 assert (Sub (And t0 t3) t2). apply IHt2.
 unfold Sub. exists c2. auto.
 unfold Sub in H6. destruct H6.
 unfold Sub in H7. destruct H7.
-exists (fun A => STLam' _ ( 
+exists (fun A => STLam' _ (
        STPair _ (STApp _ (x0 A) (STBVar _ 0)) (STApp _ (x1 A) (STBVar _ 0)))).
 apply SAnd1. auto. auto.
 inversion H1.
@@ -211,23 +219,23 @@ apply stop. (* top case *)
 Defined.
 
 (* Hints Reflexivity *)
-Hint Resolve sint sfun sand1 sand2 sand3 SInt SFun SAnd1 SAnd2 SAnd3 stop USInt USFun USAnd1 USAnd2 USAnd3 USTop.
+Hint Resolve sint (* sfun *) sand1 sand2 sand3 SInt (* SFun *) SAnd1 SAnd2 SAnd3 stop USInt (* USFun *) USAnd1 USAnd2 USAnd3 USTop.
 
-(* Restricted subtyping is sound and complete with respect to the unrestricted 
+(* Restricted subtyping is sound and complete with respect to the unrestricted
 subtyping relation *)
 
 Lemma sound_sub : forall t1 t2, usub t1 t2 -> Sub t1 t2.
-intros.  
+intros.
 induction H; try auto.
 Defined.
 
 Lemma complete_sub : forall t1 t2, Sub t1 t2 -> usub t1 t2.
 intros. destruct H. induction H; try auto.
-Defined.  
+Defined.
 
 (* Disjointness: Specification *)
 
-Definition OrthoS (A B : PTyp) := 
+Definition OrthoS (A B : PTyp) :=
   forall C, Sub A C -> Sub B C -> TopLike C.
 
 Lemma applyOrthoS : forall {A B}, OrthoS A B -> forall C, Sub A C -> Sub B C -> TopLike C.
@@ -239,17 +247,18 @@ Defined.
 Inductive Ortho : PTyp -> PTyp -> Prop :=
   | OAnd1 : forall t1 t2 t3, Ortho t1 t3 -> Ortho t2 t3 -> Ortho (And t1 t2) t3
   | OAnd2 : forall t1 t2 t3, Ortho t1 t2 -> Ortho t1 t3 -> Ortho t1 (And t2 t3)
-  | OIntFun : forall t1 t2, Ortho PInt (Fun t1 t2)
-  | OFunInt : forall t1 t2, Ortho (Fun t1 t2) PInt
-  | OFun : forall t1 t2 t3 t4, Ortho t2 t4 -> Ortho (Fun t1 t2) (Fun t3 t4)
+(*  | OIntFun : forall t1 t2, Ortho PInt (Fun t1 t2) *)
+(*  | OFunInt : forall t1 t2, Ortho (Fun t1 t2) PInt *)
+(*  | OFun : forall t1 t2 t3 t4, Ortho t2 t4 -> Ortho (Fun t1 t2) (Fun t3 t4) *)
   | OTop1 : forall t2, Ortho TopT t2
   | OTop2 : forall t1, Ortho t1 TopT.
 
+
 (* Well-formed types *)
 
-Inductive WFTyp : PTyp -> Prop := 
+Inductive WFTyp : PTyp -> Prop :=
   | WFInt : WFTyp PInt
-  | WFFun : forall t1 t2, WFTyp t1 -> WFTyp t2 -> WFTyp (Fun t1 t2)
+(*  | WFFun : forall t1 t2, WFTyp t1 -> WFTyp t2 -> WFTyp (Fun t1 t2) *)
   | WFAnd : forall t1 t2, WFTyp t1 -> WFTyp t2 -> OrthoS t1 t2 -> WFTyp (And t1 t2)
   | WFTop : WFTyp TopT.
 
@@ -259,7 +268,7 @@ induction t1; intros; auto.
 Defined.
 
 (*
-Lemma OrthoSNotEq : forall A B, OrthoS A B -> not (A = B). 
+Lemma OrthoSNotEq : forall A B, OrthoS A B -> not (A = B).
 intros. destruct H. destruct H. unfold not; intros. rewrite <- H2 in H0.
 assert (TopLike A). apply H0. apply reflex. apply reflex.
 contradiction.
@@ -270,8 +279,8 @@ Defined.
 
 Lemma ortho_sym : forall {A B}, OrthoS A B -> OrthoS B A.
 Proof.
-unfold OrthoS. 
-intros; auto. 
+unfold OrthoS.
+intros; auto.
 Defined.
 
 Lemma invAndS1 : forall t t1 t2, Sub t (And t1 t2) -> Sub t t1 /\ Sub t t2.
@@ -280,7 +289,7 @@ intro t; induction t; intros.
 (* Case Int *)
 inversion H. inversion H0. split; unfold Sub. exists c1. auto. exists c2. auto.
 (* Case Fun *)
-inversion H. inversion H0. split; unfold Sub. exists c1. auto. exists c2. auto.
+(* inversion H. inversion H0. split; unfold Sub. exists c1. auto. exists c2. auto. *)
 (* Case And *)
 inversion H. inversion H0. split; unfold Sub. exists c1. auto. exists c2. auto.
 assert (Sub t1 t0 /\ Sub t1 t3).
@@ -307,14 +316,13 @@ Defined.
 
 Lemma ortho_and : forall {A B C}, OrthoS A C -> OrthoS B C -> OrthoS (And A B) C.
 Proof.
-intros. unfold OrthoS. 
+intros. unfold OrthoS.
 intros.
-Require Import Coq.Program.Equality.
 destruct H1; dependent induction H1.
 apply invAndS1 in H2. destruct H2. auto.
 apply TLAnd.
-apply IHsub1; auto. 
-apply IHsub2; auto.
+eapply IHsub1. apply H. apply H0. auto. auto.
+eapply IHsub2. apply H. apply H0. auto. auto.
 apply H; unfold Sub; eauto.
 apply H0; unfold Sub; eauto.
 auto.
@@ -326,14 +334,14 @@ Lemma toplike_dec : forall t, sumbool (TopLike t) (not (TopLike t)).
 Proof.
   intro t.
   induction t.
-  - right; unfold not; intros HInv; inversion HInv. 
-  - inversion IHt2.
+  - right; unfold not; intros HInv; inversion HInv.
+  (* - inversion IHt2.
     left.
     apply TLFun.
     apply H.
     right.
     unfold not; intros HInv; inversion HInv; subst.
-    contradiction.
+    contradiction. *)
   - destruct IHt1. destruct IHt2. left. apply TLAnd; auto.
     right. unfold not. intros. inversion H; subst. contradiction.
     destruct IHt2.
@@ -358,7 +366,7 @@ Proof.
   (* Case PInt *)
   - generalize H0. clear H0. induction H; intros.
     pose (H0 PInt sint sint). inversion t0.
-    apply OIntFun.
+    (* apply OIntFun. *)
     apply OAnd2.
     apply IHWFTyp1. unfold OrthoS.
     intros; apply H2; auto.
@@ -366,7 +374,7 @@ Proof.
     intros. apply H2. auto. apply sand3. auto.
     apply OTop2.
   (* Case Fun t1 t2 *)
-  - induction H.
+  (* - induction H.
     apply OFunInt.
     apply OFun. apply IHwft1_2. auto.
     unfold OrthoS. intros.
@@ -379,7 +387,7 @@ Proof.
     apply IHWFTyp1; unfold OrthoS; auto.
     apply IHWFTyp2; unfold OrthoS; auto.
     (* Case t11 -> t12 _|_ T *)
-    apply OTop2.
+    apply OTop2. *)
   (* Case (t11 & t12) _|_ t2 *)
   - apply OAnd1; auto.
     apply IHwft1_1; auto; unfold OrthoS; auto.
@@ -390,11 +398,11 @@ Qed.
 
 (* Unique subtype contributor: Lemma 4 *)
 
-Lemma uniquesub : forall A B C, 
+Lemma uniquesub : forall A B C,
   OrthoS A B -> Sub (And A B) C -> not (TopLike C) ->  not (Sub A C /\ Sub B C).
 Proof.
 intros. unfold OrthoS in H. unfold not. intros. destruct H2.
-pose (H C H2 H3). contradiction. 
+pose (H C H2 H3). contradiction.
 Defined.
 
 (* Soundness of the disjointness algorithm: Theorem 7 *)
@@ -407,25 +415,25 @@ Proof.
   - apply ortho_and; auto.
   - apply ortho_sym; apply ortho_and; apply ortho_sym; auto.
   (* Case IntFun *)
-  - unfold OrthoS; auto.
+  (*- unfold OrthoS; auto.
     induction C; intros. inversion H0. inversion H1. inversion H. inversion H1.
     inversion H0. inversion H1; subst. inversion H. inversion H2; subst.
     apply TLAnd.
     apply IHC1; unfold Sub; eauto.
     apply IHC2; unfold Sub; eauto.
     (* TopT *)
-    apply TLTop.
+    apply TLTop. *)
   (* Case IntFun *)
-  - unfold OrthoS; auto.
+  (* - unfold OrthoS; auto.
     induction C; intros. inversion H. inversion H1. inversion H0. inversion H1.
     inversion H0. inversion H1; subst. inversion H. inversion H2; subst.
     apply TLAnd.
     apply IHC1; unfold Sub; eauto.
     apply IHC2; unfold Sub; eauto.
     (* TopT *)
-    apply TLTop.
+    apply TLTop. *)
   (* FunFun *)
-  - unfold OrthoS.
+  (* - unfold OrthoS.
     induction C; intros. inversion H1. inversion H2.
     apply TLFun.
     apply IHOrtho; inversion H0; inversion H2; inversion H1; inversion H10;
@@ -436,11 +444,12 @@ Proof.
     apply IHC2; inversion H0; inversion H2; inversion H1; inversion H9;
     unfold Sub; eauto.
     apply TLTop.
+  *)
   - unfold OrthoS; auto; intros.
     induction C; try (inversion H; inversion H1; subst). apply TLAnd.
     apply IHC1. unfold Sub. exists c1. auto.
     apply invAndS1 in H0. destruct H0. auto.
-    apply IHC2. 
+    apply IHC2.
     apply invAndS1 in H. destruct H. auto.
     apply invAndS1 in H0. destruct H0. auto.
     apply TLTop.
@@ -449,13 +458,13 @@ Proof.
     apply IHC1.
     apply invAndS1 in H. destruct H. auto.
     apply invAndS1 in H0. destruct H0. auto.
-    apply IHC2. 
+    apply IHC2.
     apply invAndS1 in H. destruct H. auto.
     unfold Sub. exists c2. auto.
     apply TLTop.
 Qed.
 
-
+(* Below is Unchanged *) (*
 Lemma foo : forall A, TopLike A -> forall e1, exists e2, and_coercion A e1 = inl e2.
   intros A T. induction T; simpl; intros.
   exists (fun A : Type => STUnit A). auto.
@@ -478,7 +487,7 @@ Proof.
   intro. intro. intro. intro. intro. intro.
   induction H1; intros.
   (* Case: Int <: Int *)
-  - inversion H1. 
+  - inversion H1.
     reflexivity.
   (* Case: Fun t1 t2 <: Fun t3 t4 *)
   - inversion H1; inversion H; inversion H0.
@@ -486,7 +495,7 @@ Proof.
     assert (c1 = c0). apply IHsub1; auto.
     rewrite H17. rewrite H18.
     reflexivity.
-  - (* Case: t <: And t1 t2 *) 
+  - (* Case: t <: And t1 t2 *)
     inversion H1; inversion H0.
     assert (c1 = c0). apply IHsub1; auto.
     assert (c2 = c3). apply IHsub2; auto.
@@ -497,7 +506,7 @@ Proof.
     (* different coercion case*)
     inversion H3.
   (* Case: And t1 t2 <: t (first) *)
-  - inversion H3; inversion H. 
+  - inversion H3; inversion H.
     (* different coercion *)
     rewrite <- H7 in H2. inversion H2.
     (* same coercion *)
@@ -535,7 +544,7 @@ Defined.
 
 (* Remaining Issues:
 
-(\(x : T) . x) (True,,3) 
+(\(x : T) . x) (True,,3)
 
 e1 : T -> T ~> (\x:().x)    e2 : Bool & Int ~> (True,3)   Bool & Int <: T ~> (\x . ())
 --------------------------------------------------------------
@@ -553,18 +562,18 @@ if A3 is FTop, then the generated coercion should always be of the form:
 
 TopLike, includes functions that return T.
 
-Int -> T & Int -> Char 
+Int -> T & Int -> Char
 
 Int -> T <: C and Int -> Char <: C -> FTop C
 
-but the types intersect, clearly 
+but the types intersect, clearly
 
 C = Int -> T
 
 A * B = not (TopLike A
 
 not (A <: B) /\ not (B <: A) /\
-forall C, A <: C and B <: C -> 
+forall C, A <: C and B <: C ->
 
 forbid TopLike Types in intersections!
 
@@ -582,7 +591,7 @@ Module EqFacts := BoolEqualityFacts(VarTyp).
 (* Our source language *)
 Inductive PExp :=
   | PFVar  : var -> PExp
-  | PBVar  : nat -> PExp                   
+  | PBVar  : nat -> PExp
   | PLit   : nat -> PExp
   | PLam   : PExp -> PExp
   | PApp   : PExp -> PExp -> PExp
@@ -630,7 +639,7 @@ Fixpoint open_rec_source (k : nat) (u : PExp) (t : PExp) {struct t} : PExp  :=
   match t with
   | PBVar i      => if Nat.eqb k i then u else (PBVar i)
   | PFVar x      => PFVar x
-  | PLit x       => PLit x                     
+  | PLit x       => PLit x
   | PLam t1      => PLam (open_rec_source (S k) u t1)
   | PApp t1 t2   => PApp (open_rec_source k u t1) (open_rec_source k u t2)
   | PMerge t1 t2 => PMerge (open_rec_source k u t1) (open_rec_source k u t2)
@@ -673,7 +682,7 @@ Proof.
   generalize dependent t2.
   generalize dependent n.
   induction t1; intros; simpl in *; rewrite union_spec in *; auto.
-  - destruct (Nat.eqb n0 n); auto. 
+  - destruct (Nat.eqb n0 n); auto.
   - rewrite <- union_spec.
     eapply IHt1.
     apply H.
@@ -699,8 +708,8 @@ Proof.
     eapply IHt1; apply H.
 Defined.
 
-  
-(* Typing rules of source language: Figure 2 
+
+(* Typing rules of source language: Figure 2
 Note that we generate an Annotated expression, which serves as evidence for bi-directional
 type-checking completness proof.
  *)
@@ -709,15 +718,15 @@ type-checking completness proof.
 
 Inductive has_type_source : context PTyp -> PExp -> PTyp -> PExp -> Prop :=
   | TyVar : forall Gamma x ty,
-            ok Gamma -> 
+            ok Gamma ->
             List.In (x,ty) Gamma ->
             WFTyp ty ->
             has_type_source Gamma (PFVar x) ty (PFVar x)
   | TyLit : forall Gamma x, ok Gamma -> has_type_source Gamma (PLit x) PInt (PLit x)
-  | TyLam : forall L Gamma t t1 A B, (forall x, not (In x L) -> 
+  | TyLam : forall L Gamma t t1 A B, (forall x, not (In x L) ->
                                   has_type_source (extend x A Gamma) (open_source t (PFVar x)) B (open_source t1 (PFVar x))) ->
-                           WFTyp A ->  
-                           has_type_source Gamma (PLam t) (Fun A B) (PAnn (PLam t1) (Fun A B)) 
+                           WFTyp A ->
+                           has_type_source Gamma (PLam t) (Fun A B) (PAnn (PLam t1) (Fun A B))
   | TyApp : forall Gamma A B t1 t1' t2 t2' ,
               has_type_source Gamma t1 (Fun A B) t1' ->
               has_type_source Gamma t2 A t2' ->
@@ -745,8 +754,8 @@ Inductive PTerm : PExp -> Prop :=
       (forall x, not (In x L) -> PTerm (open_source t1 (PFVar x))) ->
       PTerm (PLam t1)
   | PTerm_App : forall t1 t2,
-      PTerm t1 -> 
-      PTerm t2 -> 
+      PTerm t1 ->
+      PTerm t2 ->
       PTerm (PApp t1 t2)
   | PTerm_Merge : forall t1 t2,
       PTerm t1 ->
@@ -755,10 +764,10 @@ Inductive PTerm : PExp -> Prop :=
   | PTerm_Ann : forall e t,
       PTerm e ->
       PTerm (PAnn e t)
-  | PTerm_Top : PTerm PTop.  
+  | PTerm_Top : PTerm PTop.
 
 Hint Constructors PTerm.
-  
+
 Lemma open_rec_term_source_core :forall t j v i u, i <> j ->
   open_rec_source j v t = open_rec_source i u (open_rec_source j v t) ->
   t = open_rec_source i u t.
@@ -872,7 +881,7 @@ Require Import MSetProperties.
 Module MSetProperties := WPropertiesOn(VarTyp)(M).
 
 Lemma typing_weaken_source : forall G E F t T d,
-   has_type_source (E ++ G) t T d -> 
+   has_type_source (E ++ G) t T d ->
    ok (E ++ F ++ G) ->
    has_type_source (E ++ F ++ G) t T d.
 Proof.
@@ -919,10 +928,10 @@ Lemma typing_strengthen_source : forall z U E F t T d,
 Proof.
   intros.
   remember (E ++ ((z,U) :: nil) ++ F).
-  
+
   generalize dependent Heql.
   generalize dependent E.
-  
+
   induction H0; intros; auto.
   - subst; apply TyVar.
     now apply ok_remove in H0.
@@ -984,7 +993,7 @@ Proof.
   - apply TyTop.
     subst.
     now apply ok_remove in H0.
-Defined.    
+Defined.
 
 Lemma typing_source_ok_env : forall Gamma E ty e, has_type_source Gamma E ty e -> ok Gamma.
 Proof.
@@ -995,8 +1004,8 @@ Proof.
   pose (H0 _ Ha) as HInv;
   inversion HInv; auto.
 Defined.
-  
-  
+
+
 Definition has_type Gamma e t := exists s, has_type_source Gamma e t s.
 
 Definition tvar :
@@ -1008,7 +1017,7 @@ Definition tlit : forall Gamma x, ok Gamma -> has_type Gamma (PLit x) PInt.
 intros. unfold has_type. exists (PLit x); auto.
 Defined.
 
-Definition tlam : forall L Gamma t A B, (forall x, not (In x L) -> 
+Definition tlam : forall L Gamma t A B, (forall x, not (In x L) ->
                                  has_type (extend x A Gamma) (open_source t (PFVar x)) B) ->
                                has_type Gamma (PLam t) (Fun A B).
   (* To understand why this is admitted, please refer to the same definition on
@@ -1042,7 +1051,7 @@ Defined.
 
 Inductive Dir := Inf | Chk.
 
-(* bidirection type-system (algorithmic): 
+(* bidirection type-system (algorithmic):
 
 T |- e => t ~> E     (inference mode: infers the type of e producing target E) (use Inf)
 T |- e <= t ~> E     (checking mode: checks the type of e producing target E) (use Chk)
@@ -1056,7 +1065,7 @@ https://www.andres-loeh.de/LambdaPi/LambdaPi.pdf
 Inductive has_type_source_alg : context PTyp -> PExp -> Dir -> PTyp -> (SExp var) -> Prop :=
   (* Inference rules *)
   | ATyVar : forall Gamma x ty, ok Gamma -> List.In (x,ty) Gamma -> WFTyp ty ->
-                      has_type_source_alg Gamma (PFVar x) Inf ty (STFVar _ x) 
+                      has_type_source_alg Gamma (PFVar x) Inf ty (STFVar _ x)
   | ATyLit : forall Gamma x, ok Gamma -> has_type_source_alg Gamma (PLit x) Inf PInt (STLit _ x)
   | ATyApp : forall Gamma A B t1 t2 E1 E2,
               has_type_source_alg Gamma t1 Inf (Fun A B) E1 ->
@@ -1069,7 +1078,7 @@ Inductive has_type_source_alg : context PTyp -> PExp -> Dir -> PTyp -> (SExp var
                 has_type_source_alg Gamma (PMerge t1 t2) Inf (And A B) (STPair _ E1 E2)
   | ATyAnn : forall Gamma t1 A E, has_type_source_alg Gamma t1 Chk A E -> has_type_source_alg Gamma (PAnn t1 A) Inf A E
   (* Checking rules *)
-  | ATyLam : forall L Gamma t A B E, (forall x, not (In x L) -> 
+  | ATyLam : forall L Gamma t A B E, (forall x, not (In x L) ->
                                  has_type_source_alg (extend x A Gamma) (open_source t (PFVar x)) Chk B (open E (STFVar _ x))) -> WFTyp A ->
                            has_type_source_alg Gamma (PLam t) Chk (Fun A B) (STLam' _ E)
   | ATySub : forall Gamma t A B C E,
@@ -1091,7 +1100,7 @@ Proof.
   destruct B.
   right; unfold not; intros HInv; inversion HInv.
   assert (HA1: sumbool (A1 = B1) (A1 <> B1)) by (apply IHA1).
-  assert (HA2: sumbool (A2 = B2) (A2 <> B2)) by (apply IHA2).  
+  assert (HA2: sumbool (A2 = B2) (A2 <> B2)) by (apply IHA2).
   inversion HA1; subst; inversion HA2; subst.
   apply left; reflexivity.
   apply right; unfold not; intros HInv; inversion HInv; subst.
@@ -1102,12 +1111,12 @@ Proof.
   apply H; reflexivity.
   apply right; unfold not; intros HInv; inversion HInv.
   apply right; unfold not; intros HInv; inversion HInv.
-  
+
   destruct B.
   right; unfold not; intros HInv; inversion HInv.
   apply right; unfold not; intros HInv; inversion HInv.
   assert (HA1: sumbool (A1 = B1) (A1 <> B1)) by (apply IHA1).
-  assert (HA2: sumbool (A2 = B2) (A2 <> B2)) by (apply IHA2).  
+  assert (HA2: sumbool (A2 = B2) (A2 <> B2)) by (apply IHA2).
   inversion HA1; subst; inversion HA2; subst.
   apply left; reflexivity.
   apply right; unfold not; intros HInv; inversion HInv; subst.
@@ -1130,22 +1139,22 @@ Module PTypDecidable <: DecidableType.
   Definition t := PTyp.
 
   Definition eq (x : PTyp) y := (x = y).
-      
+
   Definition eq_refl : forall x : t, eq x x.
     Proof. destruct x; reflexivity. Defined.
-    
+
   Definition eq_sym : forall x y : t, eq x y -> eq y x.
     Proof. destruct x; destruct y; intros; auto; symmetry; assumption. Defined.
-  
+
   Definition eq_trans : forall x y z : t, eq x y -> eq y z -> eq x z.
     Proof. intros; rewrite H; assumption. Defined.
 
   Definition eq_equiv : Equivalence eq :=
     Build_Equivalence _ eq_refl eq_sym eq_trans.
-    
+
   Definition eq_dec : forall x y, sumbool (eq x y) (not (eq x y)).
     Proof. apply decidability_types. Defined.
-  
+
 End PTypDecidable.
 
 Import PTypDecidable.
@@ -1159,19 +1168,19 @@ Module VarTypDecidable <: DecidableType.
 
   Definition eq_equiv : Equivalence eq.
     Proof. apply VarTyp.eq_equiv. Defined.
-    
+
   Definition eq_refl : forall x : t, eq x x.
     Proof. apply reflexivity. Defined.
-    
+
   Definition eq_sym : forall x y : t, eq x y -> eq y x.
     Proof. intros; symmetry; assumption. Defined.
-  
+
   Definition eq_trans : forall x y z : t, eq x y -> eq y z -> eq x z.
     Proof. intros; rewrite H; assumption. Defined.
 
   Definition eq_dec : forall x y, sumbool (eq x y) (not (eq x y)).
     Proof. apply VarTyp.eq_dec. Defined.
-  
+
 End VarTypDecidable.
 
 Module MDec := PairDecidableType(VarTypDecidable)(PTypDecidable).
@@ -1182,11 +1191,11 @@ Lemma ok_unique_type : forall (Gamma: context PTyp) x A B,
   A = B.
 Proof.
   intros.
-  
+
   induction H.
   inversion H0.
   inversion H.
-  
+
   assert (HaA : sumbool (MDec.eq (x,A) (v, ty)) (not (MDec.eq (x,A) (v, ty)))).
   apply MDec.eq_dec.
 
@@ -1197,7 +1206,7 @@ Proof.
   inversion H2; inversion H3; simpl in *.
   subst.
   reflexivity.
-  
+
   inversion H2.
   simpl in *; subst.
   inversion H0.
@@ -1218,12 +1227,12 @@ Proof.
   apply list_impl_m in H7; contradiction.
   now apply IHok.
 
-    
+
   apply IHok.
   inversion H0; clear H0.
   split; [ (apply in_app_or in H4; inversion H4) | (apply in_app_or in H5; inversion H5) ]; try assumption; inversion H0; inversion H6; simpl in *; subst;
   exfalso; [ apply H2 | apply H3 ]; reflexivity.
-Defined.  
+Defined.
 
 Lemma typing_wf_source_alg:
   forall Gamma t T E dir, has_type_source_alg Gamma t dir T E -> WFTyp T.
@@ -1244,9 +1253,9 @@ Proof.
   assumption.
   apply WFTop.
 Defined.
-    
+
 Lemma typing_weaken_alg : forall G E F t T d dir,
-   has_type_source_alg (E ++ G) t dir T d -> 
+   has_type_source_alg (E ++ G) t dir T d ->
    ok (E ++ F ++ G) ->
    has_type_source_alg (E ++ F ++ G) t dir T d.
 Proof.
@@ -1285,7 +1294,7 @@ Proof.
     unfold not; intro HInv; destruct HInv as [HInv | [HInv | HInv]]; apply Frx; auto 8.
     assumption.
 Defined.
-    
+
 Lemma typing_strengthen_alg : forall z U E F t dir T d,
   not (In z (fv_source t)) ->
   has_type_source_alg (E ++ ((z,U) :: nil) ++ F) t dir T d ->
@@ -1293,10 +1302,10 @@ Lemma typing_strengthen_alg : forall z U E F t dir T d,
 Proof.
   intros.
   remember (E ++ ((z,U) :: nil) ++ F).
-  
+
   generalize dependent Heql.
   generalize dependent E.
-  
+
   induction H0; intros; auto.
   - subst; apply ATyVar.
     now apply ok_remove in H0.
@@ -1357,7 +1366,7 @@ Proof.
   - subst.
     apply ok_remove in H0.
     now apply ATyTop.
-Defined.    
+Defined.
 
 Lemma type_correct_alg_terms : forall Gamma E ty e dir, has_type_source_alg Gamma E dir ty e -> PTerm E.
 Proof.
@@ -1383,12 +1392,12 @@ Defined.
 Definition has_ty Gamma e d t := exists E, has_type_source_alg Gamma e d t E.
 
 Definition tylam : forall {Gamma t A B} L,
-  (forall x, not (In x L) -> 
+  (forall x, not (In x L) ->
         has_ty (extend x A Gamma) (open_source t (PFVar x)) Chk B) ->
   has_ty Gamma (PLam t) Chk (Fun A B).
 Proof.
   intros.
-  unfold has_ty in *.  
+  unfold has_ty in *.
   pick_fresh y.
   assert (Ha : not (In y L)) by (not_in_L y).
   apply H in Ha.
@@ -1457,7 +1466,7 @@ Fixpoint erase (e : PExp) : PExp :=
 
 (* Uniqueness *)
 
-Definition almost_unique (A B : PTyp) (d : Dir) : Prop := 
+Definition almost_unique (A B : PTyp) (d : Dir) : Prop :=
   match d with
     | Inf => A = B
     | Chk => True (* Is this result useful for checking: exists C, Sub C A /\ Sub C B*)
@@ -1505,7 +1514,7 @@ Lemma typ_coherence : forall Gamma e d t E1, has_type_source_alg Gamma e d t E1 
 intros Gamma e d t E1 H.
 induction H; intros.
 (* case PFVar *)
-- inversion H2; reflexivity. 
+- inversion H2; reflexivity.
 (* case STLit *)
 - inversion H0; reflexivity.
 (* Case App *)
@@ -1513,7 +1522,7 @@ induction H; intros.
   assert (Fun A B = Fun A0 B).
   apply (typ_inf_unique H H5). injection H9. intros.
   rewrite <- H9 in H5. rewrite <- H10 in H6.
-  apply IHhas_type_source_alg1 in H5. 
+  apply IHhas_type_source_alg1 in H5.
   apply IHhas_type_source_alg2 in H6.
   rewrite H5. rewrite H6. auto.
 (* Case Merge *)
@@ -1535,7 +1544,7 @@ induction H; intros.
   assert (HNotF : not (In x (fv E0))) by (not_in_L x).
   apply (open_app_eq _ _ _ _ HNotE HNotF Ha1).
   not_in_L x.
-  inversion H3. 
+  inversion H3.
 (* ATySub *)
 - inversion H2.
   subst.
@@ -1547,9 +1556,9 @@ induction H; intros.
   subst.
   assert (WFTyp A0). now apply typing_wf_source_alg in H.
   assert (WFTyp B). assumption.
-  assert (C = C0). 
-  eapply (sub_coherent _ H3 _ H6 _ H0 _ H4).  
-  subst; reflexivity. 
+  assert (C = C0).
+  eapply (sub_coherent _ H3 _ H6 _ H0 _ H4).
+  subst; reflexivity.
 (* ATyTop *)
 - now inversion H0.
 Defined.
@@ -1564,10 +1573,10 @@ apply ATyAnn. apply (ATySub _ _ ty _). apply ATyVar. auto. apply reflex.
 (* Lit *)
 apply ATyAnn. apply (ATySub _ _ PInt _). apply ATyLit. apply reflex.
 (* Lam *)
-apply ATyAnn. apply (ATyLam _ _ _ _ L). intros. 
+apply ATyAnn. apply (ATyLam _ _ _ _ L). intros.
 pose (H0 x H1). inversion h. auto.
 (* App *)
-apply ATyAnn. apply (ATySub _ _ B _). 
+apply ATyAnn. apply (ATySub _ _ B _).
 apply (ATyApp _ A). inversion IHhas_type_source1.
 inversion H1. rewrite <- H5 in H.
 auto.
@@ -1631,16 +1640,16 @@ Proof.
     erewrite <- IHt.
     reflexivity.
     apply H.
-    apply H2. 
+    apply H2.
   - reflexivity.
-Defined. 
+Defined.
 
 (** TODO move these three lemmas to the beginning **)
 
 Lemma and_coercion_inl_term :
   forall {t e},
     TopLike t ->
-    exists r, and_coercion t e = inl r /\ STTerm (r var).  
+    exists r, and_coercion t e = inl r /\ STTerm (r var).
 Proof.
   intros.
   induction H.
@@ -1663,7 +1672,7 @@ Lemma and_coercion_inl_typing :
   forall {t e Gamma},
     ok Gamma ->
     TopLike t ->
-    exists r, and_coercion t e = inl r /\ has_type_st Gamma (r var) (|t|).  
+    exists r, and_coercion t e = inl r /\ has_type_st Gamma (r var) (|t|).
 Proof.
   intros.
   induction H0.
@@ -1719,7 +1728,7 @@ Qed.
 (* Subtyping rules produce type-correct coercions: Lemma 1 *)
 Lemma type_correct_coercions :
   forall Gamma A B E, sub A B E ->
-             ok Gamma -> 
+             ok Gamma ->
              has_type_st Gamma (E var) (STFun (|A|) (|B|)) .
 Proof.
   intros.
@@ -1738,7 +1747,7 @@ Proof.
     rewrite <- open_rec_term.
     repeat apply typing_weaken_extend.
     assumption.
-    assumption. 
+    assumption.
     simpl.
     not_in_L y.
     apply MSetProperties.Dec.F.add_iff in H4; inversion H4.
@@ -1762,7 +1771,7 @@ Proof.
     rewrite <- open_rec_term.
     repeat apply typing_weaken_extend.
     assumption.
-    assumption. 
+    assumption.
     simpl.
     not_in_L y.
     apply MSetProperties.Dec.F.add_iff in H4; inversion H4.
@@ -1861,8 +1870,8 @@ Proof.
     left; reflexivity.
   - apply_fresh STTyLam' as x; cbn; apply STTyUnit.
     apply Ok_push; auto.
-Qed.  
-  
+Qed.
+
 Lemma and_coercion_proj1_term :
   forall t0 (c : Exp),
     STTerm (c var) ->
@@ -1941,7 +1950,7 @@ Proof.
   - apply_fresh STTerm_Lam' as x; cbn.
     apply STTerm_Unit.
 Qed.
-  
+
 (* Type preservation: Theorem 1 *)
 Lemma type_preservation :
   forall x ty dir E (Gamma : context PTyp) (H : has_type_source_alg Gamma x dir ty E),
@@ -1985,12 +1994,12 @@ Proof.
   - apply STTyUnit.
     apply (ok_map Gamma H).
 Defined.
-    
+
 (* Completeness *)
 
 Lemma erasure_open : forall t1 n t0 x,
   not (In x (fv_source t0)) ->
-  not (In x (fv_source t1)) ->                     
+  not (In x (fv_source t1)) ->
   erase (open_rec_source n (PFVar x) t1) = open_rec_source n (PFVar x) t0 ->
   erase t1 = t0.
 Proof.
@@ -2072,7 +2081,7 @@ apply (tysub _ _ B). auto. apply reflex. inversion H3.
 now apply typing_wf_source_alg in H5.
 (* erasure of Lam *)
 pick_fresh x. assert (has_type_source (extend x A Gamma) (open_source t0 (PFVar x)) B
-                                      (open_source t1 (PFVar x))). 
+                                      (open_source t1 (PFVar x))).
 assert (d: not (In x L)) by (not_in_L x).
 apply (H x d).
 assert ( has_ty (extend x A Gamma) (open_source t1 (PFVar x)) Inf B /\
@@ -2082,7 +2091,7 @@ apply (H0 x d). clear H H0. destruct H3.
 unfold open_source in H0, H, H1. inversion H. clear H.
 assert (Hxt0 : not (In x (fv_source t0))) by not_in_L x.
 assert (Hxt1 : not (In x (fv_source t1))) by not_in_L x.
-pose (erasure_open t1 0 t0 x Hxt0 Hxt1 H0). 
+pose (erasure_open t1 0 t0 x Hxt0 Hxt1 H0).
 rewrite e. reflexivity.
 (* Case App *)
 destruct IHhas_type_source1. destruct IHhas_type_source2.
@@ -2148,7 +2157,5 @@ apply ttop.
 auto.
 Defined.
 
-End CoherenceTop.
-
-
-
+*)
+End CoherenceTopModule.

--- a/typediff/without-function/CoherenceTop.v
+++ b/typediff/without-function/CoherenceTop.v
@@ -1,0 +1,2154 @@
+Require Import String.
+Require Import STLC.
+Require Import Coq.Structures.Equalities.
+Require Import Coq.MSets.MSetInterface.
+Require Import Arith.
+Require Import Setoid.
+
+Module CoherenceTop
+       (Import VarTyp : UsualDecidableTypeFull)
+       (Import set : MSetInterface.S).
+
+  
+Module ST := TLC(VarTyp)(set).
+Import ST.
+
+
+(* Notes:
+
+The syntax is encoded using Charguéraud's Locally nameless representation:
+
+http://www.chargueraud.org/softs/ln/
+
+We annotate the Coq theorems with the correnposing lemmas/theorems in the paper. 
+The reader can just look for:
+
+Lemma 4
+
+for example, to look for the proof of lemma 4 in the paper.
+
+All lemmas and theorems are complete: there are no uses of admit or Admitted,
+with the exceptions of "tlam" and "tylam" due to a technical limitation.
+
+*)
+
+
+(* Types *)
+
+Inductive PTyp : Type :=
+  | PInt : PTyp
+  | Fun : PTyp -> PTyp -> PTyp
+  | And : PTyp -> PTyp -> PTyp
+  | TopT : PTyp.
+
+Fixpoint ptyp2styp (t : PTyp) : STyp :=
+  match t with
+    | PInt => STInt 
+    | Fun t1 t2 => STFun (ptyp2styp t1) (ptyp2styp t2)
+    | And t1 t2 => STTuple (ptyp2styp t1) (ptyp2styp t2)
+    | TopT => STUnitT
+  end.
+
+
+Inductive TopLike : PTyp -> Prop :=
+  | TLTop : TopLike TopT
+  | TLAnd : forall A B, TopLike A -> TopLike B -> TopLike (And A B)
+  | TLFun : forall A B, TopLike B -> TopLike (Fun A B).
+
+(* Unrestricted Subtyping *)
+
+Inductive usub : PTyp -> PTyp -> Prop :=
+  | USInt : usub PInt PInt
+  | USFun : forall o1 o2 o3 o4, usub o3 o1 -> usub o2 o4 -> usub (Fun o1 o2) (Fun  o3 o4) 
+  | USAnd1 : forall t t1 t2, usub t t1 -> usub t t2 -> usub t (And  t1 t2) 
+  | USAnd2 : forall t t1 t2 , usub t1 t -> usub (And t1 t2) t 
+  | USAnd3 : forall t t1 t2, usub t2 t -> usub (And t1 t2) t 
+  | USTop : forall t, usub t TopT.
+
+(* TODO: Show transitivity of usub here, and easily derive transitivity 
+for sub *)
+
+(* Restricted Subtyping relation *)
+
+Inductive Atomic : PTyp -> Prop :=
+  | AInt : Atomic PInt
+  | AFun : forall t1 t2, Atomic (Fun t1 t2).  
+
+Fixpoint and_coercion (t : PTyp) (e : Exp) {struct t} : sum Exp Exp :=
+  match t with
+    | PInt    => inr e
+    | Fun _ B => match (and_coercion B e) with
+                  | inl l => inl (fun A : Type => STLam' A (l A))
+                  | inr r => inr r
+                 end 
+    | And A B => match (and_coercion A e, and_coercion B e) with
+                  | (inl l1, inl l2) =>
+                    inl (fun A : Type => STPair _ (l1 A) (l2 A))
+                  | _ => inr e
+                 end
+    | TopT    => inl (fun A => (STUnit A))
+  end.
+
+Definition join_sum : forall {A}, A + A -> A.
+  intros A H; destruct H as [a | a]; exact a.
+Defined.
+
+Inductive sub : PTyp -> PTyp -> Exp -> Prop :=
+  | SInt : sub PInt PInt (fun A => STLam' _ (STBVar _ 0))
+  | SFun : forall o1 o2 o3 o4 c1 c2, sub o3 o1 c1 -> sub o2 o4 c2 -> 
+     sub (Fun o1 o2) (Fun  o3 o4) (fun A => STLam' _ ( 
+       STLam' _ (STApp _ (c2 A) (STApp _ (STBVar _ 1) (STApp _ (c1 A) (STBVar _ 0))))))
+  | SAnd1 : forall t t1 t2 c1 c2, sub t t1 c1 -> sub t t2 c2 -> 
+     sub t (And  t1 t2) (fun A => STLam' _ (
+       STPair _ (STApp _ (c1 A) (STBVar _ 0)) (STApp _ (c2 A) (STBVar _ 0))))
+  | SAnd2 : forall t t1 t2 c, sub t1 t c -> Atomic t ->
+     sub (And  t1 t2) t (fun A => STLam' _ (join_sum (and_coercion t (fun A => (
+       (STApp _ (c A) (STProj1 _ (STBVar _ 0)))))) A))
+  | SAnd3 : forall t t1 t2 c, sub t2 t c -> Atomic t ->
+     sub (And  t1 t2) t (fun A => STLam' _ (join_sum (and_coercion t (fun A => (
+       (STApp _ (c A) (STProj2 _ (STBVar _ 0)))))) A))
+  | STop : forall t, sub t TopT (fun A => STLam' _ (STUnit _)).
+
+Notation "'|' t '|'" := (ptyp2styp t) (at level 60).
+
+Definition Sub (t1 t2 : PTyp) : Prop := exists (e:Exp), sub t1 t2 e.
+
+(* Smart constructors for Sub *)
+
+Definition sint : Sub PInt PInt.
+unfold Sub. exists (fun A => STLam' _ (STBVar _ 0)). 
+exact SInt.
+Defined.
+
+Definition stop : forall t, Sub t TopT.
+intros; unfold Sub.
+exists (fun A => STLam' _ (STUnit _)).
+apply STop.
+Defined.
+
+Definition sfun : forall o1 o2 o3 o4, Sub o3 o1 -> Sub o2 o4 -> Sub (Fun o1 o2) (Fun  o3 o4).
+unfold Sub; intros. destruct H. destruct H0.
+exists (fun A => STLam' _ ( 
+       STLam' _ (STApp _ (x0 A) (STApp _ (STBVar _ 1) (STApp _ (x A) (STBVar _ 0)))))).
+apply SFun. auto. auto.
+Defined.
+
+Definition sand1 : forall t t1 t2, Sub t t1 -> Sub t t2 -> Sub t (And t1 t2).
+unfold Sub. intros. destruct H. destruct H0.
+exists (fun A => STLam' _ ( 
+       STPair _ (STApp _ (x A) (STBVar _ 0)) (STApp _ (x0 A) (STBVar _ 0)))).
+apply SAnd1. auto. auto.
+Defined.
+
+Definition sand2_atomic : forall t t1 t2, Sub t1 t -> Atomic t -> Sub (And  t1 t2) t.
+unfold Sub. intro t. intros. destruct t. destruct H.
+exists (fun A => STLam' _ (join_sum (and_coercion PInt (fun A => (
+       (STApp _ (x A) (STProj1 _ (STBVar _ 0)))))) A)).
+apply SAnd2. auto. auto. destruct H.
+exists (fun A => STLam' _ (join_sum (and_coercion (Fun t3 t4) (fun A => (
+       (STApp _ (x A) (STProj1 _ (STBVar _ 0)))))) A)).
+apply SAnd2. auto. auto.
+inversion H0.
+apply stop. (* a top case here *)
+Defined.
+
+Definition sand2 : forall t t1 t2, Sub t1 t -> Sub (And t1 t2) t.
+intro t; induction t; intros.
+(* Case PInt *)
+apply sand2_atomic. auto. exact AInt.
+(* Case Fun *)
+apply sand2_atomic. auto. apply AFun.
+(* Case And *)
+unfold Sub. unfold Sub in H. destruct H. inversion H.
+assert (Sub (And t0 t3) t1). apply IHt1.
+unfold Sub. exists c1. auto. 
+assert (Sub (And t0 t3) t2). apply IHt2.
+unfold Sub. exists c2. auto.
+unfold Sub in H6. destruct H6.
+unfold Sub in H7. destruct H7.
+exists (fun A => STLam' _ (
+       STPair _ (STApp _ (x0 A) (STBVar _ 0)) (STApp _ (x1 A) (STBVar _ 0)))).
+apply SAnd1. auto. auto.
+inversion H1.
+inversion H1.
+(* Case Top *)
+apply stop. (* a top case here *)
+Defined.
+
+Definition sand3_atomic : forall t t1 t2, Sub t2 t -> Atomic t -> Sub (And  t1 t2) t.
+  unfold Sub. intro t; intros. destruct t. destruct H.
+  exists (fun A => STLam' _ (join_sum (and_coercion PInt (fun A => (
+       (STApp _ (x A) (STProj2 _ (STBVar _ 0)))))) A)).
+apply SAnd3. auto. auto. destruct H.
+exists (fun A => STLam' _ (join_sum (and_coercion (Fun t3 t4) (fun A => (
+       (STApp _ (x A) (STProj2 _ (STBVar _ 0)))))) A)).
+apply SAnd3. auto. auto.
+inversion H0.
+apply stop. (* a top case here *)
+Defined.
+
+Definition sand3 : forall t t1 t2, Sub t2 t -> Sub (And  t1 t2) t.
+intro t; induction t; intros.
+(* Case PInt *)
+apply sand3_atomic. auto. exact AInt.
+(* Case Fun *)
+apply sand3_atomic. auto. apply AFun.
+(* Case And *)
+unfold Sub. unfold Sub in H. destruct H. inversion H.
+assert (Sub (And t0 t3) t1). apply IHt1.
+unfold Sub. exists c1. auto. 
+assert (Sub (And t0 t3) t2). apply IHt2.
+unfold Sub. exists c2. auto.
+unfold Sub in H6. destruct H6.
+unfold Sub in H7. destruct H7.
+exists (fun A => STLam' _ ( 
+       STPair _ (STApp _ (x0 A) (STBVar _ 0)) (STApp _ (x1 A) (STBVar _ 0)))).
+apply SAnd1. auto. auto.
+inversion H1.
+inversion H1.
+(* Case Top *)
+apply stop. (* top case *)
+Defined.
+
+(* Hints Reflexivity *)
+Hint Resolve sint sfun sand1 sand2 sand3 SInt SFun SAnd1 SAnd2 SAnd3 stop USInt USFun USAnd1 USAnd2 USAnd3 USTop.
+
+(* Restricted subtyping is sound and complete with respect to the unrestricted 
+subtyping relation *)
+
+Lemma sound_sub : forall t1 t2, usub t1 t2 -> Sub t1 t2.
+intros.  
+induction H; try auto.
+Defined.
+
+Lemma complete_sub : forall t1 t2, Sub t1 t2 -> usub t1 t2.
+intros. destruct H. induction H; try auto.
+Defined.  
+
+(* Disjointness: Specification *)
+
+Definition OrthoS (A B : PTyp) := 
+  forall C, Sub A C -> Sub B C -> TopLike C.
+
+Lemma applyOrthoS : forall {A B}, OrthoS A B -> forall C, Sub A C -> Sub B C -> TopLike C.
+intros. auto.
+Defined.
+
+(* Disjointness: Implementation *)
+
+Inductive Ortho : PTyp -> PTyp -> Prop :=
+  | OAnd1 : forall t1 t2 t3, Ortho t1 t3 -> Ortho t2 t3 -> Ortho (And t1 t2) t3
+  | OAnd2 : forall t1 t2 t3, Ortho t1 t2 -> Ortho t1 t3 -> Ortho t1 (And t2 t3)
+  | OIntFun : forall t1 t2, Ortho PInt (Fun t1 t2)
+  | OFunInt : forall t1 t2, Ortho (Fun t1 t2) PInt
+  | OFun : forall t1 t2 t3 t4, Ortho t2 t4 -> Ortho (Fun t1 t2) (Fun t3 t4)
+  | OTop1 : forall t2, Ortho TopT t2
+  | OTop2 : forall t1, Ortho t1 TopT.
+
+(* Well-formed types *)
+
+Inductive WFTyp : PTyp -> Prop := 
+  | WFInt : WFTyp PInt
+  | WFFun : forall t1 t2, WFTyp t1 -> WFTyp t2 -> WFTyp (Fun t1 t2)
+  | WFAnd : forall t1 t2, WFTyp t1 -> WFTyp t2 -> OrthoS t1 t2 -> WFTyp (And t1 t2)
+  | WFTop : WFTyp TopT.
+
+Lemma reflex : forall (t1 : PTyp), Sub t1 t1.
+Proof.
+induction t1; intros; auto.
+Defined.
+
+(*
+Lemma OrthoSNotEq : forall A B, OrthoS A B -> not (A = B). 
+intros. destruct H. destruct H. unfold not; intros. rewrite <- H2 in H0.
+assert (TopLike A). apply H0. apply reflex. apply reflex.
+contradiction.
+Defined.
+ *)
+
+(* Lemmas needed to prove soundness of the disjointness algorithm *)
+
+Lemma ortho_sym : forall {A B}, OrthoS A B -> OrthoS B A.
+Proof.
+unfold OrthoS. 
+intros; auto. 
+Defined.
+
+Lemma invAndS1 : forall t t1 t2, Sub t (And t1 t2) -> Sub t t1 /\ Sub t t2.
+Proof.
+intro t; induction t; intros.
+(* Case Int *)
+inversion H. inversion H0. split; unfold Sub. exists c1. auto. exists c2. auto.
+(* Case Fun *)
+inversion H. inversion H0. split; unfold Sub. exists c1. auto. exists c2. auto.
+(* Case And *)
+inversion H. inversion H0. split; unfold Sub. exists c1. auto. exists c2. auto.
+assert (Sub t1 t0 /\ Sub t1 t3).
+apply IHt1.
+auto. unfold Sub. exists c. auto.
+destruct H7.
+split.
+apply sand2.
+auto.
+apply sand2.
+auto.
+assert (Sub t2 t0 /\ Sub t2 t3).
+apply IHt2.
+unfold Sub. exists c. auto.
+destruct H7.
+split.
+apply sand3.
+auto.
+apply sand3.
+auto.
+(* Top cases *)
+inversion H. inversion H0. split; unfold Sub. exists c1. auto. exists c2. auto.
+Defined.
+
+Lemma ortho_and : forall {A B C}, OrthoS A C -> OrthoS B C -> OrthoS (And A B) C.
+Proof.
+intros. unfold OrthoS. 
+intros.
+Require Import Coq.Program.Equality.
+destruct H1; dependent induction H1.
+apply invAndS1 in H2. destruct H2. auto.
+apply TLAnd.
+apply IHsub1; auto. 
+apply IHsub2; auto.
+apply H; unfold Sub; eauto.
+apply H0; unfold Sub; eauto.
+auto.
+Defined.
+
+Hint Constructors TopLike.
+
+Lemma toplike_dec : forall t, sumbool (TopLike t) (not (TopLike t)).
+Proof.
+  intro t.
+  induction t.
+  - right; unfold not; intros HInv; inversion HInv. 
+  - inversion IHt2.
+    left.
+    apply TLFun.
+    apply H.
+    right.
+    unfold not; intros HInv; inversion HInv; subst.
+    contradiction.
+  - destruct IHt1. destruct IHt2. left. apply TLAnd; auto.
+    right. unfold not. intros. inversion H; subst. contradiction.
+    destruct IHt2.
+    right. unfold not. intros. inversion H; subst. contradiction.
+    right. unfold not. intros. inversion H; subst. contradiction.
+  - left; apply TLTop.
+Defined.
+
+Lemma toplike_sub_is_toplike :
+  forall A B, TopLike A -> Sub A B -> TopLike B.
+Proof.
+  intros A B H1 H2.
+  destruct H2; induction H; auto; inversion H1; auto.
+Qed.
+
+(* Disjointness algorithm is complete: Theorem 8 *)
+
+Lemma ortho_completeness : forall t1, WFTyp t1 -> forall t2, WFTyp t2 -> OrthoS t1 t2 -> Ortho t1 t2.
+Proof.
+  intros t1 wft1.
+  induction wft1; intros.
+  (* Case PInt *)
+  - generalize H0. clear H0. induction H; intros.
+    pose (H0 PInt sint sint). inversion t0.
+    apply OIntFun.
+    apply OAnd2.
+    apply IHWFTyp1. unfold OrthoS.
+    intros; apply H2; auto.
+    apply IHWFTyp2. unfold OrthoS.
+    intros. apply H2. auto. apply sand3. auto.
+    apply OTop2.
+  (* Case Fun t1 t2 *)
+  - induction H.
+    apply OFunInt.
+    apply OFun. apply IHwft1_2. auto.
+    unfold OrthoS. intros.
+    assert (TopLike (Fun (And t1 t0) C)).
+    apply H0. apply sfun. apply sand2. apply reflex.
+    auto. apply sfun. apply sand3. apply reflex. auto.
+    now inversion H4.
+    (* Case t11 -> t12 _|_ t21 & t22 *)
+    apply OAnd2; auto.
+    apply IHWFTyp1; unfold OrthoS; auto.
+    apply IHWFTyp2; unfold OrthoS; auto.
+    (* Case t11 -> t12 _|_ T *)
+    apply OTop2.
+  (* Case (t11 & t12) _|_ t2 *)
+  - apply OAnd1; auto.
+    apply IHwft1_1; auto; unfold OrthoS; auto.
+    apply IHwft1_2; auto; unfold OrthoS; auto.
+  (* Case T _|_ t2 *)
+  - apply OTop1.
+Qed.
+
+(* Unique subtype contributor: Lemma 4 *)
+
+Lemma uniquesub : forall A B C, 
+  OrthoS A B -> Sub (And A B) C -> not (TopLike C) ->  not (Sub A C /\ Sub B C).
+Proof.
+intros. unfold OrthoS in H. unfold not. intros. destruct H2.
+pose (H C H2 H3). contradiction. 
+Defined.
+
+(* Soundness of the disjointness algorithm: Theorem 7 *)
+
+Lemma ortho_soundness : forall (t1 t2 : PTyp), Ortho t1 t2 -> OrthoS t1 t2.
+Proof.
+  intros.
+  induction H.
+  (* Hard case *)
+  - apply ortho_and; auto.
+  - apply ortho_sym; apply ortho_and; apply ortho_sym; auto.
+  (* Case IntFun *)
+  - unfold OrthoS; auto.
+    induction C; intros. inversion H0. inversion H1. inversion H. inversion H1.
+    inversion H0. inversion H1; subst. inversion H. inversion H2; subst.
+    apply TLAnd.
+    apply IHC1; unfold Sub; eauto.
+    apply IHC2; unfold Sub; eauto.
+    (* TopT *)
+    apply TLTop.
+  (* Case IntFun *)
+  - unfold OrthoS; auto.
+    induction C; intros. inversion H. inversion H1. inversion H0. inversion H1.
+    inversion H0. inversion H1; subst. inversion H. inversion H2; subst.
+    apply TLAnd.
+    apply IHC1; unfold Sub; eauto.
+    apply IHC2; unfold Sub; eauto.
+    (* TopT *)
+    apply TLTop.
+  (* FunFun *)
+  - unfold OrthoS.
+    induction C; intros. inversion H1. inversion H2.
+    apply TLFun.
+    apply IHOrtho; inversion H0; inversion H2; inversion H1; inversion H10;
+    unfold Sub; eauto.
+    apply TLAnd.
+    apply IHC1; inversion H0; inversion H2; inversion H1; inversion H9;
+    unfold Sub; eauto.
+    apply IHC2; inversion H0; inversion H2; inversion H1; inversion H9;
+    unfold Sub; eauto.
+    apply TLTop.
+  - unfold OrthoS; auto; intros.
+    induction C; try (inversion H; inversion H1; subst). apply TLAnd.
+    apply IHC1. unfold Sub. exists c1. auto.
+    apply invAndS1 in H0. destruct H0. auto.
+    apply IHC2. 
+    apply invAndS1 in H. destruct H. auto.
+    apply invAndS1 in H0. destruct H0. auto.
+    apply TLTop.
+  - unfold OrthoS; auto; intros.
+    induction C; try (inversion H0; inversion H1; subst). apply TLAnd.
+    apply IHC1.
+    apply invAndS1 in H. destruct H. auto.
+    apply invAndS1 in H0. destruct H0. auto.
+    apply IHC2. 
+    apply invAndS1 in H. destruct H. auto.
+    unfold Sub. exists c2. auto.
+    apply TLTop.
+Qed.
+
+
+Lemma foo : forall A, TopLike A -> forall e1, exists e2, and_coercion A e1 = inl e2.
+  intros A T. induction T; simpl; intros.
+  exists (fun A : Type => STUnit A). auto.
+  destruct (IHT1 e1). destruct (IHT2 e1). rewrite H, H0.
+  eauto.
+  destruct (IHT e1). rewrite H.
+  exists (fun A0 : Type => STLam' A0 (x A0)). auto.
+  Defined.
+
+Lemma same_coercion : forall A, TopLike A -> forall e1 e2, and_coercion A e1 = and_coercion A e2.
+  intros A T. induction T; simpl; intros; auto. rewrite (IHT1 e1 e2). rewrite (IHT2 e1 e2).
+  pose (foo _ T1 e2). destruct e. rewrite H. pose (foo _ T2 e2). destruct e. rewrite H0. auto.
+  rewrite (IHT e1 e2). auto.
+Defined.
+
+(* Coercive subtyping is coeherent: Lemma 3 *)
+
+Lemma sub_coherent : forall A, WFTyp A -> forall B, WFTyp B -> forall C1, sub A B C1 -> forall C2, sub A B C2 -> C1 = C2.
+Proof.
+  intro. intro. intro. intro. intro. intro.
+  induction H1; intros.
+  (* Case: Int <: Int *)
+  - inversion H1. 
+    reflexivity.
+  (* Case: Fun t1 t2 <: Fun t3 t4 *)
+  - inversion H1; inversion H; inversion H0.
+    assert (c2 = c3). apply IHsub2; auto.
+    assert (c1 = c0). apply IHsub1; auto.
+    rewrite H17. rewrite H18.
+    reflexivity.
+  - (* Case: t <: And t1 t2 *) 
+    inversion H1; inversion H0.
+    assert (c1 = c0). apply IHsub1; auto.
+    assert (c2 = c3). apply IHsub2; auto.
+    rewrite H13. rewrite H14.
+    reflexivity.
+    (* different coercion case*)
+    inversion H3.
+    (* different coercion case*)
+    inversion H3.
+  (* Case: And t1 t2 <: t (first) *)
+  - inversion H3; inversion H. 
+    (* different coercion *)
+    rewrite <- H7 in H2. inversion H2.
+    (* same coercion *)
+    assert (c = c0). apply IHsub; auto. rewrite H15.
+    reflexivity.
+    (* contradiction: not orthogonal! *)
+    assert (TopLike t0). apply H14. unfold Sub.
+    exists c; auto. unfold Sub. exists c0. auto.
+    inversion H15. rewrite <- H16 in H2. inversion H2.
+    rewrite <- H18 in H2. inversion H2.
+    simpl in H3.
+    erewrite same_coercion; auto.
+    (* top case *)
+    rewrite <- H5 in H2. inversion H2.
+    (* Case: And t1 t2 <: t (second) *)
+  - inversion H3; inversion H.
+    + rewrite <- H7 in H2. inversion H2.
+    (* contradiction: not orthogonal! *)
+    + subst.
+      assert (TopLike t0). apply H14.
+      unfold Sub. exists c0. auto.
+      unfold Sub. exists c. auto.
+      inversion H9; subst. inversion H4.
+      erewrite same_coercion; auto.
+    (* same coercion; no contradiction *)
+    + assert (c = c0). apply IHsub; auto. rewrite H15.
+      reflexivity.
+    (* top case *)
+    + rewrite <- H5 in H2. inversion H2.
+  (* last top case *)
+  - inversion H1. inversion H3. inversion H3.
+    reflexivity.
+Defined.
+
+
+(* Remaining Issues:
+
+(\(x : T) . x) (True,,3) 
+
+e1 : T -> T ~> (\x:().x)    e2 : Bool & Int ~> (True,3)   Bool & Int <: T ~> (\x . ())
+--------------------------------------------------------------
+e1 e2 : T ~> (\x:().x) ((\x.()) (True,3))
+
+Int & Int -> Char <: Int -> T ~> \x. \y . ()
+
+Basically when we have:
+
+A1 & A2 <: A3
+
+if A3 is FTop, then the generated coercion should always be of the form:
+
+\x . \y . ()
+
+TopLike, includes functions that return T.
+
+Int -> T & Int -> Char 
+
+Int -> T <: C and Int -> Char <: C -> FTop C
+
+but the types intersect, clearly 
+
+C = Int -> T
+
+A * B = not (TopLike A
+
+not (A <: B) /\ not (B <: A) /\
+forall C, A <: C and B <: C -> 
+
+forbid TopLike Types in intersections!
+
+allow Int -> String & Int -> Char, even though the types intersect
+
+ *)
+
+
+(* typing rules of lambda i *)
+
+Module EqFacts := BoolEqualityFacts(VarTyp).
+
+(* Definitions borrowed from STLC_Tutorial *)
+
+(* Our source language *)
+Inductive PExp :=
+  | PFVar  : var -> PExp
+  | PBVar  : nat -> PExp                   
+  | PLit   : nat -> PExp
+  | PLam   : PExp -> PExp
+  | PApp   : PExp -> PExp -> PExp
+  | PMerge : PExp -> PExp -> PExp
+  | PAnn   : PExp -> PTyp -> PExp (* only for the algorithmic version *)
+  | PTop   : PExp.
+
+(* Free variables *)
+
+(** Source language **)
+Fixpoint fv_source (pExp : PExp) : vars :=
+  match pExp with
+    | PFVar v => singleton v
+    | PBVar _ => empty
+    | PLit _ => empty
+    | PLam t => fv_source t
+    | PApp t1 t2 => union (fv_source t1) (fv_source t2)
+    | PMerge t1 t2 => union (fv_source t1) (fv_source t2)
+    | PAnn t1 A => fv_source t1
+    | PTop => empty
+  end.
+
+
+(* Tactics dealing with fresh variables, taken from STLC_Tutorial *)
+
+Ltac gather_vars :=
+  let A := gather_vars_with (fun x : vars => x) in
+  let B := gather_vars_with (fun x : var => singleton x) in
+  let C := gather_vars_with (fun (x : context PTyp) => dom x) in
+  let D := gather_vars_with (fun (x : context STyp) => dom x) in
+  let E := gather_vars_with (fun x : PExp => fv_source x) in
+  let F := gather_vars_with (fun (x : SExp var) => fv x) in
+  constr:(union A (union B (union C (union D (union E F))))).
+
+Ltac pick_fresh x :=
+  let L := gather_vars in (pick_fresh_gen L x).
+
+Tactic Notation "apply_fresh" constr(T) "as" ident(x) :=
+  apply_fresh_base T gather_vars x.
+
+(* Opening a term "u" with term "t" *)
+
+(** Source language **)
+Fixpoint open_rec_source (k : nat) (u : PExp) (t : PExp) {struct t} : PExp  :=
+  match t with
+  | PBVar i      => if Nat.eqb k i then u else (PBVar i)
+  | PFVar x      => PFVar x
+  | PLit x       => PLit x                     
+  | PLam t1      => PLam (open_rec_source (S k) u t1)
+  | PApp t1 t2   => PApp (open_rec_source k u t1) (open_rec_source k u t2)
+  | PMerge t1 t2 => PMerge (open_rec_source k u t1) (open_rec_source k u t2)
+  | PAnn e t     => PAnn (open_rec_source k u e) t
+  | PTop         => PTop
+  end.
+
+Definition open_source t u := open_rec_source 0 u t.
+
+
+(* Functions on contexts *)
+
+Definition conv_context (env : context PTyp) : context STyp :=
+  mapctx ptyp2styp env.
+
+Notation "'∥' t '∥'" := (conv_context t) (at level 60).
+
+Lemma ok_map : forall Gamma, ok Gamma -> ok (∥ Gamma ∥).
+Proof.
+  intros.
+  induction H.
+  simpl; auto.
+  unfold conv_context, mapctx in *.
+  unfold extend.
+  rewrite map_app.
+  simpl.
+  apply Ok_push.
+  assumption.
+  simpl.
+  change (map (fun p : var * PTyp => (fst p, | snd p |)) E) with (mapctx ptyp2styp E).
+  erewrite <- dom_map_id.
+  assumption.
+Defined.
+
+Lemma fv_source_distr :
+  forall t1 t2 x n, In x (fv_source (open_rec_source n t2 t1)) ->
+               In x (union (fv_source t1) (fv_source t2)).
+Proof.
+  intros.
+  generalize dependent t2.
+  generalize dependent n.
+  induction t1; intros; simpl in *; rewrite union_spec in *; auto.
+  - destruct (Nat.eqb n0 n); auto. 
+  - rewrite <- union_spec.
+    eapply IHt1.
+    apply H.
+  - rewrite union_spec.
+    inversion H.
+    rewrite or_comm at 1.
+    rewrite <- or_assoc.
+    left; rewrite or_comm; rewrite <- union_spec.
+    eapply IHt1_1; apply H0.
+    rewrite or_assoc.
+    right; rewrite <- union_spec.
+    eapply IHt1_2; apply H0.
+  - rewrite union_spec.
+    inversion H.
+    rewrite or_comm at 1.
+    rewrite <- or_assoc.
+    left; rewrite or_comm; rewrite <- union_spec.
+    eapply IHt1_1; apply H0.
+    rewrite or_assoc.
+    right; rewrite <- union_spec.
+    eapply IHt1_2; apply H0.
+  - rewrite <- union_spec.
+    eapply IHt1; apply H.
+Defined.
+
+  
+(* Typing rules of source language: Figure 2 
+Note that we generate an Annotated expression, which serves as evidence for bi-directional
+type-checking completness proof.
+ *)
+
+(* Declarative type system *)
+
+Inductive has_type_source : context PTyp -> PExp -> PTyp -> PExp -> Prop :=
+  | TyVar : forall Gamma x ty,
+            ok Gamma -> 
+            List.In (x,ty) Gamma ->
+            WFTyp ty ->
+            has_type_source Gamma (PFVar x) ty (PFVar x)
+  | TyLit : forall Gamma x, ok Gamma -> has_type_source Gamma (PLit x) PInt (PLit x)
+  | TyLam : forall L Gamma t t1 A B, (forall x, not (In x L) -> 
+                                  has_type_source (extend x A Gamma) (open_source t (PFVar x)) B (open_source t1 (PFVar x))) ->
+                           WFTyp A ->  
+                           has_type_source Gamma (PLam t) (Fun A B) (PAnn (PLam t1) (Fun A B)) 
+  | TyApp : forall Gamma A B t1 t1' t2 t2' ,
+              has_type_source Gamma t1 (Fun A B) t1' ->
+              has_type_source Gamma t2 A t2' ->
+              has_type_source Gamma (PApp t1 t2) B (PApp t1' t2')
+  | TyMerge : forall Gamma A B t1 t1' t2 t2' ,
+                has_type_source Gamma t1 A t1' ->
+                has_type_source Gamma t2 B t2' ->
+                OrthoS A B ->
+                has_type_source Gamma (PMerge t1 t2) (And A B) (PMerge t1' t2')
+  | TySub : forall Gamma t t' A B,
+              has_type_source Gamma t A t' ->
+              Sub A B ->
+              WFTyp B ->
+              has_type_source Gamma t B (PAnn t' B)
+  | TyTop : forall Gamma, ok Gamma -> has_type_source Gamma PTop TopT PTop.
+
+Hint Constructors has_type_source.
+
+Inductive PTerm : PExp -> Prop :=
+  | PTerm_Var : forall x,
+      PTerm (PFVar x)
+  | PTerm_Lit : forall n,
+      PTerm (PLit n)
+  | PTerm_Lam : forall L t1,
+      (forall x, not (In x L) -> PTerm (open_source t1 (PFVar x))) ->
+      PTerm (PLam t1)
+  | PTerm_App : forall t1 t2,
+      PTerm t1 -> 
+      PTerm t2 -> 
+      PTerm (PApp t1 t2)
+  | PTerm_Merge : forall t1 t2,
+      PTerm t1 ->
+      PTerm t2 ->
+      PTerm (PMerge t1 t2)
+  | PTerm_Ann : forall e t,
+      PTerm e ->
+      PTerm (PAnn e t)
+  | PTerm_Top : PTerm PTop.  
+
+Hint Constructors PTerm.
+  
+Lemma open_rec_term_source_core :forall t j v i u, i <> j ->
+  open_rec_source j v t = open_rec_source i u (open_rec_source j v t) ->
+  t = open_rec_source i u t.
+Proof.
+  intro t; induction t; intros; simpl.
+  reflexivity.
+  simpl in *.
+  case_eq (Nat.eqb i n); intros.
+  case_eq (Nat.eqb j n); intros.
+  exfalso. apply H. apply Nat.eqb_eq in H1.
+  apply Nat.eqb_eq in H2. rewrite H1, H2.
+  reflexivity.
+  rewrite H2 in H0.
+  unfold open_rec_source in H0.
+  rewrite H1 in H0.
+  assumption.
+  reflexivity.
+  reflexivity.
+  inversion H0.
+  erewrite <- IHt.
+  reflexivity.
+  apply not_eq_S.
+  apply H.
+  apply H2.
+  inversion H0.
+  erewrite <- IHt1.
+  erewrite <- IHt2.
+  reflexivity.
+  apply H.
+  apply H3.
+  apply H.
+  apply H2.
+  inversion H0.
+  erewrite <- IHt1.
+  erewrite <- IHt2.
+  reflexivity.
+  apply H.
+  apply H3.
+  apply H.
+  apply H2.
+  inversion H0.
+  erewrite <- IHt.
+  reflexivity.
+  apply H.
+  apply H2.
+  reflexivity.
+Defined.
+
+Lemma open_rec_source_term : forall t u,
+  PTerm t -> forall k, t =  open_rec_source k u t.
+Proof.
+  induction 1; intros; simpl; auto.
+  pick_fresh x.
+  rewrite <- open_rec_term_source_core with (j := 0) (v := PFVar x).
+  reflexivity.
+  auto.
+  simpl.
+  unfold open_source in *.
+  rewrite <- H0.
+  reflexivity.
+  not_in_L x.
+  rewrite <- IHPTerm1.
+  rewrite <- IHPTerm2.
+  reflexivity.
+  rewrite <- IHPTerm1.
+  rewrite <- IHPTerm2.
+  reflexivity.
+  rewrite <- IHPTerm.
+  reflexivity.
+Defined.
+
+Lemma type_correct_source_terms : forall Gamma E ty e, has_type_source Gamma E ty e -> PTerm E.
+Proof.
+  intros.
+  induction H; auto.
+  apply_fresh PTerm_Lam as x; auto.
+  apply H0; not_in_L x.
+Defined.
+
+Lemma type_correct_source_terms' : forall Gamma E ty e, has_type_source Gamma e ty E -> PTerm E.
+Proof.
+  intros.
+  induction H; auto.
+  apply PTerm_Ann.
+  apply_fresh PTerm_Lam as x; auto.
+  apply H0; not_in_L x.
+Defined.
+
+Lemma typing_wf_source :
+  forall Gamma t T E, has_type_source Gamma t T E -> WFTyp T.
+Proof.
+  intros Gamma t  T E H.
+  induction H.
+  assumption.
+  apply WFInt.
+  pick_fresh x.
+  assert (Ha : not (M.In x L)) by (not_in_L x).
+  apply WFFun.
+  apply H in Ha.
+  assumption.
+  apply H0 with (x := x); assumption.
+  inversion IHhas_type_source1; assumption.
+  apply WFAnd; try assumption.
+  assumption.
+  apply WFTop.
+Defined.
+
+Require Import Coq.Logic.Classical_Prop.
+Require Import Coq.Program.Equality.
+Require Import MSetProperties.
+Module MSetProperties := WPropertiesOn(VarTyp)(M).
+
+Lemma typing_weaken_source : forall G E F t T d,
+   has_type_source (E ++ G) t T d -> 
+   ok (E ++ F ++ G) ->
+   has_type_source (E ++ F ++ G) t T d.
+Proof.
+  intros.
+  generalize dependent H0.
+  remember (E ++ G) as H'.
+  generalize dependent HeqH'.
+  generalize dependent E.
+  dependent induction H; intros; eauto.
+  (* STTyVar *)
+  - subst.
+    apply TyVar.
+    assumption.
+    apply in_app_or in H0.
+    inversion H0.
+    apply in_or_app; left; assumption.
+    apply in_or_app; right; apply in_or_app; right; assumption.
+    assumption.
+  (* STTyLam *)
+  - unfold extend in *.
+    apply_fresh TyLam as x.
+    unfold open in *; simpl in *.
+    unfold extend.
+    rewrite app_assoc.
+    apply H0.
+    not_in_L x.
+    rewrite HeqH'.
+    rewrite <- app_assoc.
+    reflexivity.
+    rewrite <- app_assoc.
+    apply Ok_push.
+    assumption.
+    repeat (rewrite dom_union; rewrite union_spec).
+    repeat rewrite union_spec in Frx.
+    repeat rewrite or_assoc in *.
+    unfold not; intro HInv; destruct HInv as [HInv | [HInv | HInv]]; apply Frx; auto 8.
+    assumption.
+Defined.
+
+Lemma typing_strengthen_source : forall z U E F t T d,
+  not (In z (fv_source t)) ->
+  has_type_source (E ++ ((z,U) :: nil) ++ F) t T d ->
+  has_type_source (E ++ F) t T d.
+Proof.
+  intros.
+  remember (E ++ ((z,U) :: nil) ++ F).
+  
+  generalize dependent Heql.
+  generalize dependent E.
+  
+  induction H0; intros; auto.
+  - subst; apply TyVar.
+    now apply ok_remove in H0.
+    apply in_or_app.
+    repeat apply in_app_or in H1.
+    inversion H1.
+    auto.
+    apply in_app_or in H3.
+    inversion H3.
+    inversion H4.
+    inversion H5.
+    subst.
+    exfalso; apply H; simpl.
+    left; reflexivity.
+    inversion H5.
+    auto.
+    assumption.
+  - apply TyLit.
+    subst.
+    now apply ok_remove in H0.
+
+  - subst.
+    apply_fresh TyLam as x.
+    unfold extend in *; simpl in *.
+    rewrite app_comm_cons.
+    apply H1.
+    not_in_L x.
+    not_in_L z.
+    apply fv_source_distr in H3.
+    rewrite union_spec in H3.
+    inversion H3.
+    auto.
+    assert (NeqXZ : not (In x (singleton z))) by (not_in_L x).
+    simpl in H4.
+    exfalso; apply NeqXZ.
+    apply MSetProperties.Dec.F.singleton_2.
+    apply MSetProperties.Dec.F.singleton_1 in H4.
+    symmetry; assumption.
+    rewrite app_comm_cons.
+    reflexivity.
+    assumption.
+  - eapply TyApp.
+    subst.
+    apply IHhas_type_source1; simpl in *; not_in_L z; reflexivity.
+    subst.
+    apply IHhas_type_source2; simpl in *; not_in_L z; reflexivity.
+  - subst.
+    apply TyMerge.
+    apply IHhas_type_source1; simpl in *; not_in_L z; reflexivity.
+    apply IHhas_type_source2; simpl in *; not_in_L z; reflexivity.
+    assumption.
+  - subst.
+    eapply TySub.
+    apply IHhas_type_source.
+    assumption.
+    reflexivity.
+    apply H1.
+    assumption.
+  - apply TyTop.
+    subst.
+    now apply ok_remove in H0.
+Defined.    
+
+Lemma typing_source_ok_env : forall Gamma E ty e, has_type_source Gamma E ty e -> ok Gamma.
+Proof.
+  intros.
+  induction H; auto;
+  pick_fresh x;
+  assert (Ha: not (In x L)) by not_in_L x;
+  pose (H0 _ Ha) as HInv;
+  inversion HInv; auto.
+Defined.
+  
+  
+Definition has_type Gamma e t := exists s, has_type_source Gamma e t s.
+
+Definition tvar :
+  forall Gamma x ty, ok Gamma -> List.In (x,ty) Gamma -> WFTyp ty -> has_type Gamma (PFVar x) ty.
+intros.  unfold has_type. exists (PFVar x). auto.
+Defined.
+
+Definition tlit : forall Gamma x, ok Gamma -> has_type Gamma (PLit x) PInt.
+intros. unfold has_type. exists (PLit x); auto.
+Defined.
+
+Definition tlam : forall L Gamma t A B, (forall x, not (In x L) -> 
+                                 has_type (extend x A Gamma) (open_source t (PFVar x)) B) ->
+                               has_type Gamma (PLam t) (Fun A B).
+  (* To understand why this is admitted, please refer to the same definition on
+     CoherenceBasicBD.v *)
+Admitted.
+
+Definition tapp : forall Gamma A B t1 t2,
+              has_type Gamma t1 (Fun A B)  ->
+              has_type Gamma t2 A  ->
+              has_type Gamma (PApp t1 t2) B.
+unfold has_type. intros. destruct H, H0.
+exists (PApp x x0). apply (TyApp _ A); auto.
+Defined.
+
+Definition tmerge : forall Gamma A B t1 t2,
+                has_type Gamma t1 A ->
+                has_type Gamma t2 B ->
+                OrthoS A B ->
+                has_type Gamma (PMerge t1 t2) (And A B).
+unfold has_type. intros. destruct H, H0.
+exists (PMerge x x0). apply (TyMerge); auto.
+Defined.
+
+Definition tsub : forall Gamma t A B, has_type Gamma t A -> Sub A B -> WFTyp B -> has_type Gamma t B.
+unfold has_type. intros. destruct H. exists (PAnn x B). apply (TySub _ _ _ A); auto.
+Defined.
+
+Definition ttop : forall Gamma, ok Gamma -> has_type Gamma PTop TopT.
+intros. unfold has_type. exists PTop. apply TyTop. auto.
+Defined.
+
+Inductive Dir := Inf | Chk.
+
+(* bidirection type-system (algorithmic): 
+
+T |- e => t ~> E     (inference mode: infers the type of e producing target E) (use Inf)
+T |- e <= t ~> E     (checking mode: checks the type of e producing target E) (use Chk)
+
+Inspiration for the rules:
+
+https://www.andres-loeh.de/LambdaPi/LambdaPi.pdf
+
+*)
+
+Inductive has_type_source_alg : context PTyp -> PExp -> Dir -> PTyp -> (SExp var) -> Prop :=
+  (* Inference rules *)
+  | ATyVar : forall Gamma x ty, ok Gamma -> List.In (x,ty) Gamma -> WFTyp ty ->
+                      has_type_source_alg Gamma (PFVar x) Inf ty (STFVar _ x) 
+  | ATyLit : forall Gamma x, ok Gamma -> has_type_source_alg Gamma (PLit x) Inf PInt (STLit _ x)
+  | ATyApp : forall Gamma A B t1 t2 E1 E2,
+              has_type_source_alg Gamma t1 Inf (Fun A B) E1 ->
+              has_type_source_alg Gamma t2 Chk A E2 ->
+              has_type_source_alg Gamma (PApp t1 t2) Inf B (STApp _ E1 E2)
+  | ATyMerge : forall Gamma A B t1 t2 E1 E2,
+                has_type_source_alg Gamma t1 Inf A E1 ->
+                has_type_source_alg Gamma t2 Inf B E2 ->
+                OrthoS A B ->
+                has_type_source_alg Gamma (PMerge t1 t2) Inf (And A B) (STPair _ E1 E2)
+  | ATyAnn : forall Gamma t1 A E, has_type_source_alg Gamma t1 Chk A E -> has_type_source_alg Gamma (PAnn t1 A) Inf A E
+  (* Checking rules *)
+  | ATyLam : forall L Gamma t A B E, (forall x, not (In x L) -> 
+                                 has_type_source_alg (extend x A Gamma) (open_source t (PFVar x)) Chk B (open E (STFVar _ x))) -> WFTyp A ->
+                           has_type_source_alg Gamma (PLam t) Chk (Fun A B) (STLam' _ E)
+  | ATySub : forall Gamma t A B C E,
+               has_type_source_alg Gamma t Inf A E ->
+               sub A B C ->
+               WFTyp B ->
+               has_type_source_alg Gamma t Chk B (STApp _ (C var) E)
+  | ATyTop : forall Gamma, ok Gamma -> has_type_source_alg Gamma PTop Inf TopT (STUnit _).
+
+Hint Constructors has_type_source_alg.
+
+Lemma decidability_types :
+  forall (A B : PTyp), sumbool (A = B) (not (A = B)).
+Proof.
+  intros A.
+  induction A.
+  destruct B; auto; apply right; unfold not; intros H; inversion H.
+
+  destruct B.
+  right; unfold not; intros HInv; inversion HInv.
+  assert (HA1: sumbool (A1 = B1) (A1 <> B1)) by (apply IHA1).
+  assert (HA2: sumbool (A2 = B2) (A2 <> B2)) by (apply IHA2).  
+  inversion HA1; subst; inversion HA2; subst.
+  apply left; reflexivity.
+  apply right; unfold not; intros HInv; inversion HInv; subst.
+  apply H; reflexivity.
+  apply right; unfold not; intros HInv; inversion HInv; subst.
+  apply H; reflexivity.
+  apply right; unfold not; intros HInv; inversion HInv; subst.
+  apply H; reflexivity.
+  apply right; unfold not; intros HInv; inversion HInv.
+  apply right; unfold not; intros HInv; inversion HInv.
+  
+  destruct B.
+  right; unfold not; intros HInv; inversion HInv.
+  apply right; unfold not; intros HInv; inversion HInv.
+  assert (HA1: sumbool (A1 = B1) (A1 <> B1)) by (apply IHA1).
+  assert (HA2: sumbool (A2 = B2) (A2 <> B2)) by (apply IHA2).  
+  inversion HA1; subst; inversion HA2; subst.
+  apply left; reflexivity.
+  apply right; unfold not; intros HInv; inversion HInv; subst.
+  apply H; reflexivity.
+  apply right; unfold not; intros HInv; inversion HInv; subst.
+  apply H; reflexivity.
+  apply right; unfold not; intros HInv; inversion HInv; subst.
+  apply H; reflexivity.
+  apply right; unfold not; intros HInv; inversion HInv.
+
+  destruct B.
+  apply right; unfold not; intros HInv; inversion HInv.
+  apply right; unfold not; intros HInv; inversion HInv.
+  apply right; unfold not; intros HInv; inversion HInv.
+  apply left; reflexivity.
+Defined.
+
+Module PTypDecidable <: DecidableType.
+
+  Definition t := PTyp.
+
+  Definition eq (x : PTyp) y := (x = y).
+      
+  Definition eq_refl : forall x : t, eq x x.
+    Proof. destruct x; reflexivity. Defined.
+    
+  Definition eq_sym : forall x y : t, eq x y -> eq y x.
+    Proof. destruct x; destruct y; intros; auto; symmetry; assumption. Defined.
+  
+  Definition eq_trans : forall x y z : t, eq x y -> eq y z -> eq x z.
+    Proof. intros; rewrite H; assumption. Defined.
+
+  Definition eq_equiv : Equivalence eq :=
+    Build_Equivalence _ eq_refl eq_sym eq_trans.
+    
+  Definition eq_dec : forall x y, sumbool (eq x y) (not (eq x y)).
+    Proof. apply decidability_types. Defined.
+  
+End PTypDecidable.
+
+Import PTypDecidable.
+Require Import Coq.Structures.DecidableTypeEx.
+
+Module VarTypDecidable <: DecidableType.
+
+  Definition t := VarTyp.t.
+
+  Definition eq (x : VarTyp.t) y := (VarTyp.eq x y).
+
+  Definition eq_equiv : Equivalence eq.
+    Proof. apply VarTyp.eq_equiv. Defined.
+    
+  Definition eq_refl : forall x : t, eq x x.
+    Proof. apply reflexivity. Defined.
+    
+  Definition eq_sym : forall x y : t, eq x y -> eq y x.
+    Proof. intros; symmetry; assumption. Defined.
+  
+  Definition eq_trans : forall x y z : t, eq x y -> eq y z -> eq x z.
+    Proof. intros; rewrite H; assumption. Defined.
+
+  Definition eq_dec : forall x y, sumbool (eq x y) (not (eq x y)).
+    Proof. apply VarTyp.eq_dec. Defined.
+  
+End VarTypDecidable.
+
+Module MDec := PairDecidableType(VarTypDecidable)(PTypDecidable).
+
+Lemma ok_unique_type : forall (Gamma: context PTyp) x A B,
+  ok Gamma ->
+  List.In (x, A) Gamma /\ List.In (x, B) Gamma ->
+  A = B.
+Proof.
+  intros.
+  
+  induction H.
+  inversion H0.
+  inversion H.
+  
+  assert (HaA : sumbool (MDec.eq (x,A) (v, ty)) (not (MDec.eq (x,A) (v, ty)))).
+  apply MDec.eq_dec.
+
+  assert (HaB : sumbool (MDec.eq (x,B) (v, ty)) (not (MDec.eq (x,B) (v, ty)))).
+  apply MDec.eq_dec.
+
+  inversion HaA; inversion HaB.
+  inversion H2; inversion H3; simpl in *.
+  subst.
+  reflexivity.
+  
+  inversion H2.
+  simpl in *; subst.
+  inversion H0.
+  inversion H5; inversion H6.
+  inversion H8; subst; reflexivity.
+  inversion H7; subst.
+  apply list_impl_m in H8; contradiction.
+  inversion H8; subst; reflexivity.
+  now apply IHok.
+
+  inversion H3.
+  simpl in *; subst.
+  inversion H0.
+  inversion H5; inversion H6.
+  inversion H7; inversion H8; subst; reflexivity.
+  inversion H7; subst; reflexivity.
+  inversion H8; subst.
+  apply list_impl_m in H7; contradiction.
+  now apply IHok.
+
+    
+  apply IHok.
+  inversion H0; clear H0.
+  split; [ (apply in_app_or in H4; inversion H4) | (apply in_app_or in H5; inversion H5) ]; try assumption; inversion H0; inversion H6; simpl in *; subst;
+  exfalso; [ apply H2 | apply H3 ]; reflexivity.
+Defined.  
+
+Lemma typing_wf_source_alg:
+  forall Gamma t T E dir, has_type_source_alg Gamma t dir T E -> WFTyp T.
+Proof.
+  intros Gamma t dir T E H.
+  induction H.
+  assumption.
+  apply WFInt.
+  inversion IHhas_type_source_alg1; assumption.
+  apply WFAnd; try assumption.
+  assumption.
+  pick_fresh x.
+  assert (Ha : not (M.In x L)) by (not_in_L x).
+  apply WFFun.
+  apply H in Ha.
+  assumption.
+  apply H0 with (x := x); assumption.
+  assumption.
+  apply WFTop.
+Defined.
+    
+Lemma typing_weaken_alg : forall G E F t T d dir,
+   has_type_source_alg (E ++ G) t dir T d -> 
+   ok (E ++ F ++ G) ->
+   has_type_source_alg (E ++ F ++ G) t dir T d.
+Proof.
+  intros.
+  generalize dependent H0.
+  remember (E ++ G) as H'.
+  generalize dependent HeqH'.
+  generalize dependent E.
+  dependent induction H; intros; eauto.
+  (* STTyVar *)
+  - subst.
+    apply ATyVar.
+    assumption.
+    apply in_app_or in H0.
+    inversion H0.
+    apply in_or_app; left; assumption.
+    apply in_or_app; right; apply in_or_app; right; assumption.
+    assumption.
+  (* STTyLam *)
+  - unfold extend in *.
+    apply_fresh ATyLam as x.
+    unfold open in *; simpl in *.
+    unfold extend.
+    rewrite app_assoc.
+    apply H0.
+    not_in_L x.
+    rewrite HeqH'.
+    rewrite <- app_assoc.
+    reflexivity.
+    rewrite <- app_assoc.
+    apply Ok_push.
+    assumption.
+    repeat (rewrite dom_union; rewrite M.union_spec).
+    repeat rewrite M.union_spec in Frx.
+    repeat rewrite or_assoc in *.
+    unfold not; intro HInv; destruct HInv as [HInv | [HInv | HInv]]; apply Frx; auto 8.
+    assumption.
+Defined.
+    
+Lemma typing_strengthen_alg : forall z U E F t dir T d,
+  not (In z (fv_source t)) ->
+  has_type_source_alg (E ++ ((z,U) :: nil) ++ F) t dir T d ->
+  has_type_source_alg (E ++ F) t dir T d.
+Proof.
+  intros.
+  remember (E ++ ((z,U) :: nil) ++ F).
+  
+  generalize dependent Heql.
+  generalize dependent E.
+  
+  induction H0; intros; auto.
+  - subst; apply ATyVar.
+    now apply ok_remove in H0.
+    apply in_or_app.
+    repeat apply in_app_or in H1.
+    inversion H1.
+    auto.
+    apply in_app_or in H3.
+    inversion H3.
+    inversion H4.
+    inversion H5.
+    subst.
+    exfalso; apply H; simpl.
+    left; reflexivity.
+    inversion H5.
+    auto.
+    assumption.
+  - apply ATyLit.
+    subst.
+    now apply ok_remove in H0.
+  - eapply ATyApp.
+    subst.
+    apply IHhas_type_source_alg1; simpl in *; not_in_L z; reflexivity.
+    subst.
+    apply IHhas_type_source_alg2; simpl in *; not_in_L z; reflexivity.
+  - subst.
+    apply ATyMerge.
+    apply IHhas_type_source_alg1; simpl in *; not_in_L z; reflexivity.
+    apply IHhas_type_source_alg2; simpl in *; not_in_L z; reflexivity.
+    assumption.
+  - subst.
+    apply_fresh ATyLam as x.
+    unfold extend in *; simpl in *.
+    rewrite app_comm_cons.
+    apply H1.
+    not_in_L x.
+    not_in_L z.
+    apply fv_source_distr in H3.
+    rewrite union_spec in H3.
+    inversion H3.
+    auto.
+    assert (NeqXZ : not (In x (singleton z))) by (not_in_L x).
+    simpl in H4.
+    exfalso; apply NeqXZ.
+    apply MSetProperties.Dec.F.singleton_2.
+    apply MSetProperties.Dec.F.singleton_1 in H4.
+    symmetry; assumption.
+    rewrite app_comm_cons.
+    reflexivity.
+    assumption.
+  - subst.
+    eapply ATySub.
+    apply IHhas_type_source_alg.
+    assumption.
+    reflexivity.
+    apply H1.
+    assumption.
+  - subst.
+    apply ok_remove in H0.
+    now apply ATyTop.
+Defined.    
+
+Lemma type_correct_alg_terms : forall Gamma E ty e dir, has_type_source_alg Gamma E dir ty e -> PTerm E.
+Proof.
+  intros.
+  induction H; auto.
+  apply_fresh PTerm_Lam as x; auto.
+  apply H0; not_in_L x.
+Defined.
+
+
+Lemma typing_alg_ok_env : forall Gamma E dir ty e, has_type_source_alg Gamma E dir ty e -> ok Gamma.
+Proof.
+  intros.
+  induction H; auto;
+  pick_fresh x;
+  assert (Ha: not (In x L)) by not_in_L x;
+  pose (H0 _ Ha) as HInv;
+  inversion HInv; auto.
+Defined.
+
+(* Ignoring the generated expressions + smart constructors *)
+
+Definition has_ty Gamma e d t := exists E, has_type_source_alg Gamma e d t E.
+
+Definition tylam : forall {Gamma t A B} L,
+  (forall x, not (In x L) -> 
+        has_ty (extend x A Gamma) (open_source t (PFVar x)) Chk B) ->
+  has_ty Gamma (PLam t) Chk (Fun A B).
+Proof.
+  intros.
+  unfold has_ty in *.  
+  pick_fresh y.
+  assert (Ha : not (In y L)) by (not_in_L y).
+  apply H in Ha.
+  inversion Ha.
+  (* we will have the same problem present in the definition of "tlam" *)
+Admitted.
+
+Definition tyvar : forall Gamma x ty, ok Gamma -> List.In (x,ty) Gamma -> WFTyp ty ->
+                                      has_ty Gamma (PFVar x) Inf ty.
+intros.
+unfold has_ty. exists (STFVar _ x). apply ATyVar; auto.
+Defined.
+
+Definition tylit : forall Gamma x, ok Gamma -> has_ty Gamma (PLit x) Inf PInt.
+intros. unfold has_ty.
+exists (STLit _ x); auto.
+Defined.
+
+Definition tyapp : forall Gamma A B t1 t2,
+              has_ty Gamma t1 Inf (Fun A B) ->
+              has_ty Gamma t2 Chk A ->
+              has_ty Gamma (PApp t1 t2) Inf B.
+intros. unfold has_ty.
+inversion H. inversion H0.
+exists (STApp _ x x0).
+apply (ATyApp _ A). auto. auto.
+Defined.
+
+Definition tymerge : forall Gamma A B t1 t2,
+                has_ty Gamma t1 Inf A ->
+                has_ty Gamma t2 Inf B ->
+                OrthoS A B ->
+                has_ty Gamma (PMerge t1 t2) Inf (And A B).
+intros.
+inversion H. inversion H0.
+unfold has_ty. exists (STPair _ x x0). apply ATyMerge; auto.
+Defined.
+
+Definition tyann : forall Gamma t1 A, has_ty Gamma t1 Chk A -> has_ty Gamma (PAnn t1 A) Inf A.
+intros. inversion H. unfold has_ty. exists x. apply ATyAnn. auto.
+Defined.
+
+Lemma tysub : forall Gamma t A B, has_ty Gamma t Inf A -> Sub A B -> WFTyp B -> has_ty Gamma t Chk B.
+intros.
+unfold has_ty.
+inversion H. inversion H0.
+exists ((STApp _ (x0 var) x)).
+apply  (ATySub _ _ A); auto.
+Defined.
+
+Lemma tytop : forall Gamma : context PTyp, ok Gamma -> has_ty Gamma PTop Inf TopT.
+intros. unfold has_ty. exists (STUnit _). apply ATyTop. auto.
+Defined.
+
+Fixpoint erase (e : PExp) : PExp :=
+  match e with
+    | PFVar x => PFVar x
+    | PBVar x => PBVar x
+    | PLit x => PLit x
+    | PLam e => PLam (erase e)
+    | PApp e1 e2 => PApp (erase e1) (erase e2)
+    | PMerge e1 e2 => PMerge (erase e1) (erase e2)
+    | PAnn e t => erase e
+    | PTop => PTop
+  end.
+
+(* Uniqueness *)
+
+Definition almost_unique (A B : PTyp) (d : Dir) : Prop := 
+  match d with
+    | Inf => A = B
+    | Chk => True (* Is this result useful for checking: exists C, Sub C A /\ Sub C B*)
+  end.
+
+
+Lemma typ_unique : forall Gamma e d t1 E1, has_type_source_alg Gamma e d t1 E1 -> forall t2 E2, has_type_source_alg Gamma e d t2 E2 -> almost_unique t1 t2 d.
+intros Gamma e d t1 E1 H.
+induction H; intros; unfold almost_unique.
+(* case Var *)
+- inversion H2; subst.
+  rewrite (ok_unique_type _ _ _ _ H (conj H0 H5)).
+  reflexivity.
+(* case Lit *)
+- inversion H0. auto.
+(* case App *)
+- inversion H1.
+  apply IHhas_type_source_alg1 in H5. simpl in H5.
+  apply IHhas_type_source_alg2 in H6.
+  injection H5. intros. auto.
+(* Case Merge *)
+- inversion H2.
+  apply IHhas_type_source_alg1 in H5.
+  apply IHhas_type_source_alg2 in H7.
+  rewrite H5. rewrite H7. auto.
+(* Case Ann *)
+- inversion H0. auto.
+(* Case Lam *)
+- auto.
+(* case Sub *)
+- auto.
+(* case Top *)
+- now inversion H0.
+Defined.
+
+(* Type inference always gives unique types: Theorem 5 *)
+
+Lemma typ_inf_unique : forall {Gamma e t1 E1}, has_type_source_alg Gamma e Inf t1 E1 -> forall {t2 E2}, has_type_source_alg Gamma e Inf t2 E2 -> t1 = t2.
+intros.
+pose (@typ_unique _ _ _ _ _ H _ _ H0). simpl in a. auto.
+Defined.
+
+(* Theorem 6 *)
+Lemma typ_coherence : forall Gamma e d t E1, has_type_source_alg Gamma e d t E1 -> forall E2, has_type_source_alg Gamma e d t E2 -> E1 = E2.
+intros Gamma e d t E1 H.
+induction H; intros.
+(* case PFVar *)
+- inversion H2; reflexivity. 
+(* case STLit *)
+- inversion H0; reflexivity.
+(* Case App *)
+- inversion H1.
+  assert (Fun A B = Fun A0 B).
+  apply (typ_inf_unique H H5). injection H9. intros.
+  rewrite <- H9 in H5. rewrite <- H10 in H6.
+  apply IHhas_type_source_alg1 in H5. 
+  apply IHhas_type_source_alg2 in H6.
+  rewrite H5. rewrite H6. auto.
+(* Case Merge *)
+- inversion H2.
+  apply IHhas_type_source_alg1 in H8.
+  apply IHhas_type_source_alg2 in H9.
+  rewrite H8. rewrite H9. auto.
+(* Case Ann *)
+- inversion H0.
+  apply IHhas_type_source_alg in H3. auto.
+(* Case Lam *)
+- inversion H2; subst.
+  apply f_equal.
+  pick_fresh x.
+  assert (Ha1: not (M.In x L0)) by (not_in_L x).
+  apply H7 in Ha1.
+  apply H0 in Ha1.
+  assert (HNotE : not (In x (fv E))) by (not_in_L x).
+  assert (HNotF : not (In x (fv E0))) by (not_in_L x).
+  apply (open_app_eq _ _ _ _ HNotE HNotF Ha1).
+  not_in_L x.
+  inversion H3. 
+(* ATySub *)
+- inversion H2.
+  subst.
+  inversion H.
+  assert (A = A0).
+  apply (typ_inf_unique H H3).
+  subst.
+  apply IHhas_type_source_alg in H3.
+  subst.
+  assert (WFTyp A0). now apply typing_wf_source_alg in H.
+  assert (WFTyp B). assumption.
+  assert (C = C0). 
+  eapply (sub_coherent _ H3 _ H6 _ H0 _ H4).  
+  subst; reflexivity. 
+(* ATyTop *)
+- now inversion H0.
+Defined.
+
+(*
+Lemma has_type_completeness : forall Gamma e t, has_type_source Gamma e t -> has_type_source_alg Gamma (PAnn e t) Inf t.
+Proof.
+intros.
+induction H.
+(* Var *)
+apply ATyAnn. apply (ATySub _ _ ty _). apply ATyVar. auto. apply reflex.
+(* Lit *)
+apply ATyAnn. apply (ATySub _ _ PInt _). apply ATyLit. apply reflex.
+(* Lam *)
+apply ATyAnn. apply (ATyLam _ _ _ _ L). intros. 
+pose (H0 x H1). inversion h. auto.
+(* App *)
+apply ATyAnn. apply (ATySub _ _ B _). 
+apply (ATyApp _ A). inversion IHhas_type_source1.
+inversion H1. rewrite <- H5 in H.
+auto.
+*)
+
+
+(* TODO move this and merge with CoherenceBasic *)
+Lemma in_persists : forall x ty Gamma, List.In (x, ty) Gamma -> List.In (x, |ty|) (∥ Gamma ∥).
+Proof.
+  intros.
+  induction Gamma.
+  simpl in *; assumption.
+  simpl in *.
+  inversion H.
+  subst; simpl in *.
+  auto.
+  right; apply IHGamma; auto.
+Defined.
+
+Lemma open_rec_term_core :
+  forall t j v i u, i <> j -> open_rec_source j (PFVar v) t = open_rec_source i (PFVar u) (open_rec_source j (PFVar v) t) ->
+    t = open_rec_source i (PFVar u) t.
+Proof.
+  intro t; induction t; intros; simpl.
+  - reflexivity.
+  - simpl in *.
+    case_eq (Nat.eqb i n); intros.
+    case_eq (Nat.eqb j n); intros.
+    exfalso. apply H. apply Nat.eqb_eq in H1.
+    apply Nat.eqb_eq in H2. rewrite H1, H2.
+    reflexivity.
+    rewrite H2 in H0.
+    unfold open_rec_source in H0.
+    rewrite H1 in H0.
+    assumption.
+    reflexivity.
+  - reflexivity.
+  - inversion H0.
+    erewrite <- IHt.
+    reflexivity.
+    apply not_eq_S.
+    apply H.
+    apply H2.
+  - inversion H0.
+    erewrite <- IHt1.
+    erewrite <- IHt2.
+    reflexivity.
+    apply H.
+    apply H3.
+    apply H.
+    apply H2.
+  - inversion H0.
+    erewrite <- IHt1.
+    erewrite <- IHt2.
+    reflexivity.
+    apply H.
+    apply H3.
+    apply H.
+    apply H2.
+  - inversion H0.
+    erewrite <- IHt.
+    reflexivity.
+    apply H.
+    apply H2. 
+  - reflexivity.
+Defined. 
+
+(** TODO move these three lemmas to the beginning **)
+
+Lemma and_coercion_inl_term :
+  forall {t e},
+    TopLike t ->
+    exists r, and_coercion t e = inl r /\ STTerm (r var).  
+Proof.
+  intros.
+  induction H.
+  - exists (fun A : Type => STUnit A); auto.
+  - destruct IHTopLike1, IHTopLike2, H1, H2.
+    simpl; rewrite H1, H2.
+    exists (fun A0 : Type => STPair A0 (x A0) (x0 A0)); auto.
+  - inversion IHTopLike.
+    exists (fun A : Type => STLam' A (x A)).
+    inversion H0.
+    split.
+    simpl.
+    rewrite H1.
+    reflexivity.
+    apply_fresh STTerm_Lam' as x.
+    unfold open; rewrite <- open_rec_term; auto.
+Qed.
+
+Lemma and_coercion_inl_typing :
+  forall {t e Gamma},
+    ok Gamma ->
+    TopLike t ->
+    exists r, and_coercion t e = inl r /\ has_type_st Gamma (r var) (|t|).  
+Proof.
+  intros.
+  induction H0.
+  - exists (fun A : Type =>  STUnit A); auto.
+  - destruct IHTopLike1, IHTopLike2.
+    destruct H0, H1.
+    exists (fun A : Type => STPair A (x A) (x0 A)).
+    split; simpl.
+    now rewrite H0, H1.
+    apply STTyPair; auto.
+  - destruct IHTopLike.
+    exists (fun A : Type => STLam' A (x A)).
+    simpl.
+    destruct H1.
+    rewrite H1.
+    split.
+    reflexivity.
+    apply_fresh STTyLam' as v.
+    unfold open.
+    rewrite <- open_rec_term.
+    rewrite <- app_nil_l with (l := extend v (| A |) Gamma).
+    apply typing_weaken; rewrite app_nil_l.
+    apply H2.
+    apply Ok_push; assumption.
+    now apply typing_gives_terms in H2.
+Qed.
+
+Lemma and_coercion_inr :
+  forall {t e},
+    not (TopLike t) ->
+    and_coercion t e = inr e.
+Proof.
+  intros.
+  generalize dependent e.
+  induction t0; try simpl; auto.
+  - intros.
+    assert (not (TopLike t0_2)).
+    unfold not; intros HTS; apply H.
+    apply TLFun; apply HTS.
+    apply IHt0_2 with (e := e) in H0.
+    rewrite H0.
+    reflexivity.
+  - intros.
+    assert (Ha : ~ TopLike t0_1 \/ ~ TopLike t0_2) by
+        (apply not_and_or; unfold not; intros; apply H; now apply TLAnd).
+    destruct Ha.
+    rewrite IHt0_1; auto.
+    rewrite IHt0_2; auto.
+    now destruct (and_coercion t0_1 e).
+  - exfalso; apply H; apply TLTop.
+Qed.
+
+(* Subtyping rules produce type-correct coercions: Lemma 1 *)
+Lemma type_correct_coercions :
+  forall Gamma A B E, sub A B E ->
+             ok Gamma -> 
+             has_type_st Gamma (E var) (STFun (|A|) (|B|)) .
+Proof.
+  intros.
+  induction H.
+  (* Case SInt *)
+  - simpl.
+    apply_fresh STTyLam' as x; cbn.
+    simpl; apply STTyVar.
+    apply Ok_push; auto.
+    left; simpl; auto.
+  (* Case SFun *)
+  - apply_fresh STTyLam' as x; cbn.
+    apply_fresh STTyLam' as y; cbn.
+    apply STTyApp with (A := (| o2 |)).
+    rewrite <- open_rec_term.
+    rewrite <- open_rec_term.
+    repeat apply typing_weaken_extend.
+    assumption.
+    assumption. 
+    simpl.
+    not_in_L y.
+    apply MSetProperties.Dec.F.add_iff in H4; inversion H4.
+    exfalso; apply H2; apply MSetProperties.Dec.F.singleton_2; auto.
+    assumption.
+    now apply typing_gives_terms in IHsub2.
+    rewrite <- open_rec_term.
+    now apply typing_gives_terms in IHsub2.
+    now apply typing_gives_terms in IHsub2.
+    eapply STTyApp.
+    apply STTyVar.
+    apply Ok_push.
+    apply Ok_push.
+    assumption.
+    assumption.
+    not_in_L y.
+    not_in_L x.
+    right; left; reflexivity.
+    apply STTyApp with (A := (| o3 |)).
+    rewrite <- open_rec_term.
+    rewrite <- open_rec_term.
+    repeat apply typing_weaken_extend.
+    assumption.
+    assumption. 
+    simpl.
+    not_in_L y.
+    apply MSetProperties.Dec.F.add_iff in H4; inversion H4.
+    exfalso; apply H2; apply MSetProperties.Dec.F.singleton_2; auto.
+    assumption.
+    now apply typing_gives_terms in IHsub1.
+    rewrite <- open_rec_term; now apply typing_gives_terms in IHsub1.
+    apply STTyVar.
+    apply Ok_push.
+    apply Ok_push.
+    assumption.
+    assumption.
+    simpl.
+    rewrite union_spec in Fry.
+    apply not_or_and in Fry.
+    inversion Fry.
+    unfold not; intros.
+    apply MSetProperties.Dec.F.add_iff in H4.
+    inversion H4.
+    apply H2.
+    apply MSetProperties.Dec.F.singleton_2; assumption.
+    contradiction.
+    left; reflexivity.
+  (* Case SAnd1 *)
+  - apply_fresh STTyLam' as x; cbn.
+    apply STTyPair.
+    eapply STTyApp.
+    rewrite <- open_rec_term.
+    apply typing_weaken_extend.
+    apply IHsub1.
+    assumption.
+    now apply typing_gives_terms in IHsub1.
+    apply STTyVar.
+    apply Ok_push; auto.
+    left; reflexivity.
+    eapply STTyApp.
+    rewrite <- open_rec_term.
+    apply typing_weaken_extend.
+    apply IHsub2.
+    assumption.
+    now apply typing_gives_terms in IHsub2.
+    apply STTyVar.
+    apply Ok_push; auto.
+    left; reflexivity.
+  - pose (toplike_dec t0).
+    inversion s; clear s.
+    assert (Ha : exists r, and_coercion t0 ((fun A : Type => STApp A (c A) (STProj1 A (STBVar A 0)))) = inl r /\ has_type_st Gamma (r var) (|t0|)) by (apply and_coercion_inl_typing; auto).
+    destruct Ha as [r [HCoerce HHasTy]].
+    rewrite HCoerce.
+    apply_fresh STTyLam' as x.
+    simpl.
+    unfold open; rewrite <- open_rec_term.
+    rewrite <- app_nil_l with (l := (extend x (STTuple (| t1 |) (| t2 |)) Gamma)).
+    apply typing_weaken; rewrite app_nil_l.
+    apply HHasTy.
+    apply Ok_push; auto.
+    now apply typing_gives_terms in HHasTy.
+    eapply and_coercion_inr in H2.
+    rewrite H2; simpl.
+    apply_fresh STTyLam' as x; cbn.
+    eapply STTyApp.
+    rewrite <- open_rec_term.
+    apply typing_weaken_extend.
+    apply IHsub.
+    assumption.
+    now apply typing_gives_terms in IHsub.
+    eapply STTyProj1.
+    apply STTyVar.
+    apply Ok_push; auto.
+    left; reflexivity.
+  - pose (toplike_dec t0).
+    inversion s; clear s.
+    assert (Ha : exists r, and_coercion t0 ((fun A : Type => STApp A (c A) (STProj2 A (STBVar A 0)))) = inl r /\ has_type_st Gamma (r var) (|t0|)) by (apply and_coercion_inl_typing; auto).
+    destruct Ha as [r [HCoerce HHasTy]].
+    rewrite HCoerce.
+    apply_fresh STTyLam' as x.
+    simpl.
+    unfold open; rewrite <- open_rec_term.
+    rewrite <- app_nil_l with (l := (extend x (STTuple (| t1 |) (| t2 |)) Gamma)).
+    apply typing_weaken; rewrite app_nil_l.
+    apply HHasTy.
+    apply Ok_push; auto.
+    now apply typing_gives_terms in HHasTy.
+    eapply and_coercion_inr in H2.
+    rewrite H2; simpl.
+    apply_fresh STTyLam' as x; cbn.
+    eapply STTyApp.
+    rewrite <- open_rec_term.
+    apply typing_weaken_extend.
+    apply IHsub.
+    assumption.
+    now apply typing_gives_terms in IHsub.
+    eapply STTyProj2.
+    apply STTyVar.
+    apply Ok_push; auto.
+    left; reflexivity.
+  - apply_fresh STTyLam' as x; cbn; apply STTyUnit.
+    apply Ok_push; auto.
+Qed.  
+  
+Lemma and_coercion_proj1_term :
+  forall t0 (c : Exp),
+    STTerm (c var) ->
+    STTerm (STLam' var (join_sum (and_coercion t0 (fun A : Type => (STApp A (c A) (STProj1 A (STBVar A 0)))))
+        var)).
+Proof.
+  intros.
+  apply_fresh STTerm_Lam' as x; unfold open; simpl.
+  pose (toplike_dec t0).
+  inversion s; clear s.
+  assert (exists r : Exp, and_coercion t0 (fun A : Type =>
+                          STApp A (c A) (STProj1 A (STBVar A 0))) = inl r /\ STTerm (r var)).
+  apply and_coercion_inl_term; auto.
+  inversion H1.
+  inversion H2.
+  rewrite H3.
+  simpl.
+  rewrite <- open_rec_term; auto.
+  eapply and_coercion_inr in H0.
+  rewrite H0.
+  simpl.
+  apply STTerm_App; auto.
+  rewrite <- open_rec_term; auto.
+Qed.
+
+Lemma and_coercion_proj2_term :
+  forall t0 (c : Exp),
+    STTerm (c var) ->
+    STTerm (STLam' var (join_sum (and_coercion t0 (fun A : Type => (STApp A (c A) (STProj2 A (STBVar A 0)))))
+        var)).
+Proof.
+  intros.
+  apply_fresh STTerm_Lam' as x; unfold open; simpl.
+  pose (toplike_dec t0).
+  inversion s; clear s.
+  assert (exists r : Exp, and_coercion t0 (fun A : Type =>
+                          STApp A (c A) (STProj2 A (STBVar A 0))) = inl r /\ STTerm (r var)).
+  apply and_coercion_inl_term; auto.
+  inversion H1.
+  inversion H2.
+  rewrite H3.
+  simpl.
+  rewrite <- open_rec_term; auto.
+  eapply and_coercion_inr in H0.
+  rewrite H0.
+  simpl.
+  apply STTerm_App; auto.
+  rewrite <- open_rec_term; auto.
+Qed.
+
+Lemma coercions_produce_terms :
+  forall E A B, sub A B E -> STTerm (E var).
+Proof.
+  intros.
+  induction H.
+  (* Case SInt *)
+  - apply_fresh STTerm_Lam' as x. cbn; auto.
+  (* Case SFun *)
+  - apply_fresh STTerm_Lam' as x; cbn.
+    apply_fresh STTerm_Lam' as y; cbn.
+    apply STTerm_App.
+    repeat rewrite <- open_rec_term; assumption.
+    apply STTerm_App.
+    apply STTerm_Var.
+    apply STTerm_App; [ repeat rewrite <- open_rec_term; auto | apply STTerm_Var ].
+  (* Case SAnd1 *)
+  - apply_fresh STTerm_Lam' as x; cbn.
+    apply STTerm_Pair.
+    apply STTerm_App; repeat rewrite <- open_rec_term; auto.
+    rewrite <- open_rec_term; auto.
+  (* Case SAnd2 *)
+  - apply and_coercion_proj1_term; auto.
+  (* Case SAnd3 *)
+  - apply and_coercion_proj2_term; auto.
+  (* Case STop *)
+  - apply_fresh STTerm_Lam' as x; cbn.
+    apply STTerm_Unit.
+Qed.
+  
+(* Type preservation: Theorem 1 *)
+Lemma type_preservation :
+  forall x ty dir E (Gamma : context PTyp) (H : has_type_source_alg Gamma x dir ty E),
+  has_type_st (∥ Gamma ∥) E (|ty|).
+Proof.
+  intros.
+  induction H; subst.
+  (* TyVar *)
+  - apply STTyVar.
+    apply (ok_map Gamma H).
+    now apply in_persists.
+  (* TyLit *)
+  - apply STTyLit.
+    apply (ok_map Gamma H).
+  (* TyApp *)
+  - simpl in *.
+    apply STTyApp with (A := |A|).
+    assumption.
+    assumption.
+  (* TyMerge *)
+  - simpl; apply STTyPair; assumption.
+  (* TyAnn *)
+  - auto.
+  (* TyLam *)
+  - simpl.
+    apply_fresh STTyLam' as x.
+    unfold open; simpl.
+    assert (Ha : not (M.In x L)).
+    not_in_L x.
+    apply H0 in Ha.
+    simpl in *.
+    unfold extend.
+    simpl.
+    apply Ha.
+  (* ATySub *)
+  - apply STTyApp with (|A|).
+    apply type_correct_coercions.
+    assumption.
+    now apply typing_ok_env in IHhas_type_source_alg.
+    assumption.
+  - apply STTyUnit.
+    apply (ok_map Gamma H).
+Defined.
+    
+(* Completeness *)
+
+Lemma erasure_open : forall t1 n t0 x,
+  not (In x (fv_source t0)) ->
+  not (In x (fv_source t1)) ->                     
+  erase (open_rec_source n (PFVar x) t1) = open_rec_source n (PFVar x) t0 ->
+  erase t1 = t0.
+Proof.
+  induction t1; intros; simpl in H1.
+  (* PFVar *)
+  - destruct t0; try (now (simpl in H1; inversion H1)).
+    simpl in *.
+    destruct (Nat.eqb n n0).
+    exfalso; apply H0; apply MSetProperties.Dec.F.singleton_2; now inversion H1.
+    inversion H1.
+  (* PBVar *)
+  - destruct t0; try now (simpl in *; destruct (Nat.eqb n0 n); inversion H1).
+    simpl in *.
+    case_eq (Nat.eqb n0 n); intros; simpl in *.
+    rewrite H2 in H1.
+    exfalso; apply H; apply MSetProperties.Dec.F.singleton_2; now inversion H1.
+    rewrite H2 in H1.
+    inversion H1.
+    simpl in *.
+    case_eq (Nat.eqb n0 n); intros; case_eq (Nat.eqb n0 n1); intros; simpl in *.
+    apply beq_nat_true in H2; apply beq_nat_true in H3.
+    subst; auto.
+    rewrite H2 in H1; rewrite H3 in H1; simpl in *; inversion H1.
+    rewrite H2 in H1; rewrite H3 in H1; simpl in *; inversion H1.
+    rewrite H2 in H1; rewrite H3 in H1; simpl in *; assumption.
+  (* Lit *)
+  - destruct t0; simpl in H; (try inversion H1).
+    destruct (Nat.eqb n0 n1); inversion H3.
+    auto.
+  (* Lam *)
+  - destruct t0; simpl in *; try now inversion H1.
+    destruct (Nat.eqb n n0); inversion H1.
+    inversion H1; now rewrite (IHt1 (S n) t0 x H H0 H3).
+  (* App *)
+  - destruct t0; simpl in *; try now inversion H1.
+    destruct (Nat.eqb n n0); inversion H1.
+    inversion H1.
+    rewrite union_spec in H, H0.
+    apply not_or_and in H; apply not_or_and in H0.
+    inversion H as [xt01 xt02]; inversion H0 as [xt11 xt12].
+    rewrite (IHt1_1 n t0_1 x xt01 xt11 H3).
+    rewrite (IHt1_2 n t0_2 x xt02 xt12 H4).
+    reflexivity.
+  (* Merge *)
+  - destruct t0; simpl in *; try now inversion H1.
+    destruct (Nat.eqb n n0); inversion H1.
+    inversion H1.
+    rewrite union_spec in H, H0.
+    apply not_or_and in H; apply not_or_and in H0.
+    inversion H as [xt01 xt02]; inversion H0 as [xt11 xt12].
+    rewrite (IHt1_1 n t0_1 x xt01 xt11 H3).
+    rewrite (IHt1_2 n t0_2 x xt02 xt12 H4).
+    reflexivity.
+  (* Ann *)
+  - simpl in *.
+    erewrite (IHt1 n t0 x H H0 H1).
+    reflexivity.
+  - simpl in *.
+    destruct t0; simpl in *; try now inversion H1.
+    destruct (Nat.eqb n n0); inversion H1.
+Qed.
+
+(* Theorem 4 *)
+Lemma typ_complete : forall Gamma e t e',
+  has_type_source Gamma e t e' -> (has_ty Gamma e' Inf t) /\ erase e' = e.
+intros Gamma e t e' H.
+induction H; intros; split; try (simpl; auto).
+(* Case TyVar *)
+apply tyvar; auto.
+(* Case TyLit *)
+apply tylit; auto.
+(* Case TyLam *)
+apply tyann.
+apply (tylam (union (union (union L (dom Gamma)) (fv_source t0)) (fv_source t1))).
+intros.
+assert (d: not (In x L)) by (not_in_L x).
+pose (H0 x d). destruct a. (*destruct H2. destruct x0.*)
+apply (tysub _ _ B). auto. apply reflex. inversion H3.
+now apply typing_wf_source_alg in H5.
+(* erasure of Lam *)
+pick_fresh x. assert (has_type_source (extend x A Gamma) (open_source t0 (PFVar x)) B
+                                      (open_source t1 (PFVar x))). 
+assert (d: not (In x L)) by (not_in_L x).
+apply (H x d).
+assert ( has_ty (extend x A Gamma) (open_source t1 (PFVar x)) Inf B /\
+         erase (open_source t1 (PFVar x)) = open_source t0 (PFVar x)).
+assert (d: not (In x L)) by (not_in_L x).
+apply (H0 x d). clear H H0. destruct H3.
+unfold open_source in H0, H, H1. inversion H. clear H.
+assert (Hxt0 : not (In x (fv_source t0))) by not_in_L x.
+assert (Hxt1 : not (In x (fv_source t1))) by not_in_L x.
+pose (erasure_open t1 0 t0 x Hxt0 Hxt1 H0). 
+rewrite e. reflexivity.
+(* Case App *)
+destruct IHhas_type_source1. destruct IHhas_type_source2.
+apply (tyapp _ A).
+inversion H1.
+unfold has_ty. exists x. auto.
+apply (tysub _ _ A). auto. apply reflex. now apply typing_wf_source in H0.
+(* erasure of App *)
+destruct IHhas_type_source1. destruct IHhas_type_source2.
+rewrite H2. rewrite H4. auto.
+(* Case Merge *)
+destruct IHhas_type_source1.
+destruct IHhas_type_source2.
+apply tymerge; auto.
+(* erasure of Merge *)
+destruct IHhas_type_source1. destruct IHhas_type_source2.
+subst; auto.
+(* Case Ann *)
+destruct IHhas_type_source.
+apply tyann. apply (tysub _ _ A); auto.
+destruct IHhas_type_source.
+auto.
+(* Case Top *)
+apply tytop.
+auto.
+Defined.
+
+Lemma erase_open : forall t n e,
+                     erase (open_rec_source n e t) = open_rec_source n (erase e) (erase t).
+induction t0; intros; simpl; try auto. destruct (Nat.eqb n0 n); auto.
+(* don't know how to deal with this in Coq 8.5, but should be trivially true :) *)
+rewrite (IHt0 (S n) e). reflexivity.
+rewrite (IHt0_1 n e). rewrite (IHt0_2 n e). reflexivity.
+rewrite (IHt0_1 n e). rewrite (IHt0_2 n e). reflexivity.
+Defined.
+
+(* Theorem 3 *)
+Lemma typ_sound : forall e d A Gamma, has_ty Gamma e d A -> has_type Gamma (erase e) A.
+intros.
+inversion H. clear H.
+induction H0; simpl.
+(* PFVar *)
+apply tvar; auto.
+(* PFLit *)
+apply tlit; auto.
+(* App *)
+apply (tapp _ A). auto. auto.
+(* Merge *)
+apply tmerge; auto.
+(* Ann *)
+apply (tsub _ _ A). auto. apply reflex.
+now apply typing_wf_source_alg in H0.
+(* Lam *)
+apply_fresh tlam as x.
+assert (d: not (In x L)) by (not_in_L x).
+intros. pose (H0 x d).
+unfold open_source in h. unfold open_source.
+rewrite (erase_open t0 0 (PFVar x)) in h. auto.
+(* Sub *)
+apply (tsub _ _ A). auto. unfold Sub. exists C. auto. auto.
+(* Top *)
+apply ttop.
+auto.
+Defined.
+
+End CoherenceTop.
+
+
+

--- a/typediff/without-function/STLC.v
+++ b/typediff/without-function/STLC.v
@@ -1,0 +1,1072 @@
+Require Import Coq.Arith.EqNat.
+Require Import Coq.Structures.Equalities.
+Require Import Coq.Lists.List.
+Require Import Coq.MSets.MSetInterface.
+Require Import Coq.MSets.MSetWeakList.
+Require Import Coq.Logic.Classical_Prop.
+Require Import Coq.Program.Equality.
+Require Import Coq.Arith.PeanoNat.
+Require Import MSetProperties.
+Require Import Coq.Init.Specif.
+
+Module TLC
+       (Import VarTyp : UsualDecidableTypeFull)
+       (Import set : MSetInterface.S).
+
+Module EqFacts := BoolEqualityFacts(VarTyp).
+
+Module M := MSetWeakList.Make(VarTyp).
+Export M.
+  
+Module MSetProperties := WPropertiesOn(VarTyp)(M).
+
+Inductive STyp :=
+  | STUnitT : STyp
+  | STInt : STyp
+  | STFun : STyp -> STyp -> STyp
+  | STTuple : STyp -> STyp -> STyp.
+
+Inductive SExp (A : Type) :=
+  | STFVar  : A -> SExp A
+  | STBVar  : nat -> SExp A
+  | STUnit  : SExp A
+  | STLit   : nat -> SExp A
+  | STLam   : STyp -> SExp A -> SExp A
+  | STLam'  : SExp A -> SExp A
+  | STApp   : SExp A -> SExp A -> SExp A
+  | STPair  : SExp A -> SExp A -> SExp A
+  | STProj1 : SExp A -> SExp A
+  | STProj2 : SExp A -> SExp A.
+
+Definition Exp := forall A, SExp A.
+
+Definition var : Type := VarTyp.t.
+
+Definition vars := M.t.
+
+(** Definitions borrowed from STLC_Tutorial **)
+
+(* Contexts *)
+Definition context (A : Type) := list (var * A). 
+
+Definition extend {A} (x : var) (a : A) (c : context A) : context A :=
+  ((x,a) :: nil) ++ c.
+
+Definition dom {A} (c : context A) : vars :=
+  fold_right (fun el r => add (fst el) r) empty c.
+
+(* Functions on contexts *)
+Definition mapctx {A B} (f : A -> B) (c : context A) : context B :=
+  map (fun p => (fst p, (f (snd p)))) c.
+
+Lemma cons_to_push : forall {A} x v (E : context A),
+  (x, v) :: E = extend x v E.
+Proof. intros; unfold extend; simpl; reflexivity. Defined.
+
+Lemma env_ind : forall {A} (P : context A -> Prop),
+  (P nil) ->
+  (forall E x v, P E -> P (extend x v E)) ->
+  (forall E, P E).
+Proof.
+  unfold extend.
+  induction E as [|(x,v)].
+  assumption.
+  pose (H0 _ x v IHE).
+  now simpl in p.
+Defined.
+
+Lemma dom_map_id : forall (A B : Type) (E : context A) (f : A -> B),
+  dom E = dom (mapctx f E).
+Proof.
+  unfold mapctx.
+  intros.
+  induction E.
+  simpl; reflexivity.
+  simpl in *.
+  rewrite IHE.
+  reflexivity.
+Defined.
+
+Lemma dom_union : forall (A : Type) (E G : context A) x,
+  M.In x (dom (E ++ G)) <-> M.In x (M.union (dom E) (dom G)).
+Proof.
+  intros. generalize dependent G.
+  induction E; intros.
+  unfold dom at 2; simpl.
+  unfold "<->".
+  split; intros.
+  apply MSetProperties.Dec.F.union_3.
+  assumption.
+  apply MSetProperties.Dec.F.union_1 in H.
+  inversion H.
+  inversion H0.
+  assumption.
+  simpl.
+  destruct a.
+  split; intros.
+  simpl in *.
+  assert (Ha : sumbool (VarTyp.eq v x) (not( VarTyp.eq v x))) by apply VarTyp.eq_dec.
+  destruct Ha.
+  apply MSetProperties.Dec.F.union_2.
+  apply MSetProperties.Dec.F.add_iff.
+  auto.
+  rewrite (MSetProperties.Dec.F.add_neq_iff _ n) in H.
+  assert (Ha : M.Equal (M.union (M.add v (dom E)) (dom G)) (M.add v (M.union (dom E) (dom G)))) by apply MSetProperties.union_add.
+  apply Ha.
+  apply IHE in H.
+  unfold not in n.
+  apply MSetProperties.Dec.F.add_2.
+  assumption.
+  simpl in *.
+  apply MSetProperties.Dec.F.union_1 in H.
+  destruct H.
+  assert (Ha : sumbool (VarTyp.eq v x) (not( VarTyp.eq v x))) by apply VarTyp.eq_dec.
+  destruct Ha.
+  apply MSetProperties.Dec.F.add_iff; auto.
+  rewrite (MSetProperties.Dec.F.add_neq_iff _ n) in H.
+  apply MSetProperties.Dec.F.add_neq_iff; auto.
+  apply IHE.
+  apply MSetProperties.Dec.F.union_2; assumption.
+  apply MSetProperties.Dec.F.add_iff.
+  right.
+  apply IHE.
+  apply MSetProperties.Dec.F.union_3; assumption.
+Defined.
+
+Lemma list_impl_m : forall {A} Gamma x (v : A), List.In (x, v) Gamma -> M.In x (dom Gamma).
+Proof.
+  intros.
+  induction Gamma.
+  inversion H.
+  simpl.
+  destruct a.
+  simpl in *.
+  inversion H.
+  apply MSetProperties.Dec.F.add_1.
+  apply f_equal with (f := fst) in H0.
+  simpl in H0.
+  rewrite H0.
+  reflexivity.
+  apply MSetProperties.Dec.F.add_2.
+  apply IHGamma; assumption.
+Defined.
+
+Ltac not_in_L x :=
+  repeat rewrite dom_union; repeat rewrite M.union_spec;
+  repeat match goal with
+    | H: M.In x M.empty |- _ => inversion H
+    | H:_ |- context [M.In x (dom nil)] => simpl
+    | H:_ |- context [M.In x (dom ((?v, ?t) :: ?l))] => simpl; rewrite MSetProperties.Dec.F.add_iff
+    | H: _ |- context [M.In ?v (dom ((x, ?t) :: ?l))] => simpl; rewrite MSetProperties.Dec.F.add_iff
+    | H1: ~ ?l, H2: ?l |- _ => contradiction
+    | H: ~ M.In ?y (M.singleton x) |- not (x = ?y) => rewrite MSetProperties.Dec.F.singleton_iff in H; assumption 
+    | H: ~ M.In x (M.singleton ?y) |- not (x = ?y) => rewrite MSetProperties.Dec.F.singleton_iff in H; unfold not; intros; apply H; symmetry; assumption
+    | H: ~ M.In x (M.add ?v M.empty) |- _ => rewrite <- MSetProperties.singleton_equal_add in H 
+    | H: not (M.In x (dom ?l)) |- _ => rewrite dom_union in H; simpl in H
+    | H: not (M.In x (M.union ?l1 ?l2)) |- _ =>
+      rewrite M.union_spec in H
+    | H: not (M.In x ?l3 \/ ?l) |- _ =>
+      let l := fresh in
+      let r := fresh in
+      apply not_or_and in H; destruct H as [l r]
+    | H: not (?l \/ M.In x ?l3) |- _ =>
+      let l := fresh in
+      let r := fresh in
+      apply not_or_and in H; destruct H as [l r]
+    | H: not (M.In x ?l1) |- not (M.In x ?l1) => assumption
+    | H:_ |- ~ (x = ?v \/ M.In ?v ?l) => unfold not; intro HInv; inversion HInv as [HH | HH]
+    | H:_ |- not (?A \/ ?B) => apply and_not_or; split
+    | H1: ~ M.In x (M.singleton ?v), H2: ?v = x |- _ => exfalso; apply H1; apply MSetProperties.Dec.F.singleton_2; assumption
+    | H1: ~ M.In x (M.singleton ?v), H2: x = ?v |- _ => exfalso; apply H1; apply MSetProperties.Dec.F.singleton_2; symmetry; assumption
+    | H: not (M.In x ?l1) |- not (M.In x ?l2) =>
+      unfold not; intros; apply H; repeat rewrite M.union_spec; auto 10 
+  end.
+
+(* Ok *)
+
+Inductive ok {A} : context A -> Prop :=
+  | Ok_nil : ok nil
+  | Ok_push : forall (E : context A) (v : var) (ty : A),
+                ok E -> not (In v (dom E)) -> ok (extend v ty E).        
+
+Hint Constructors ok.
+
+Lemma ok_app_l : forall {A} (E F : context A), ok (E ++ F) -> ok E.
+Proof.
+  intros A E; induction E; intros.
+  apply Ok_nil.
+  inversion H.
+  subst.
+  apply Ok_push.
+  apply (IHE _ H2).
+  not_in_L v.
+Defined.  
+  
+Lemma ok_app_r : forall {A} (E F : context A), ok (E ++ F) -> ok F.
+Proof.
+  intros A E.
+  induction E; intros.
+  - rewrite app_nil_l in H.
+    auto.
+  - inversion H; subst.
+    apply (IHE _ H2).
+Defined.
+
+Lemma ok_remove : forall {A} (E F G : context A), ok (E ++ G ++ F) -> ok (E ++ F).
+Proof.
+  intros.
+  induction E using env_ind.
+  rewrite app_nil_l in *.
+  now apply ok_app_r in H.
+  unfold extend; rewrite <- app_assoc.
+  apply Ok_push.
+  apply IHE.
+  unfold extend in H; rewrite <- app_assoc in H.
+  inversion H; subst.
+  assumption.
+  unfold extend in H.
+  inversion H; subst.
+  rewrite dom_union in *.
+  rewrite union_spec in *.
+  unfold not; intros.
+  apply H4.
+  inversion H0.
+  auto.
+  right.
+  rewrite dom_union; rewrite union_spec.
+  auto.
+Defined.
+  
+Lemma ok_extend_comm : forall {A} (E F : context A) x v,
+               ok (F ++ E ++ (x, v) :: nil) ->
+               ok (F ++ (x, v) :: nil ++ E).
+Proof.
+  intros A E F x v HOk.  
+  generalize dependent E.
+  
+  induction F using env_ind; intros.
+  unfold extend; simpl.
+  rewrite app_nil_l in HOk.
+  apply Ok_push.
+  now apply ok_app_l in HOk.
+  induction E.
+  unfold not; intros HInv; inversion HInv.
+  simpl.
+  rewrite <- app_comm_cons in HOk.
+  inversion HOk; subst.
+  apply IHE in H1.
+  simpl in *.
+  unfold not; intros H3; apply MSetProperties.Dec.F.add_iff in H3.
+  inversion H3.
+  rewrite H in H2.
+  rewrite dom_union in H2.
+  rewrite union_spec in H2.
+  apply not_or_and in H2.
+  inversion H2.
+  simpl in H4.
+  apply H4.
+  apply MSetProperties.Dec.F.add_1.
+  reflexivity.
+  contradiction.
+  unfold extend.
+  rewrite <- app_assoc.
+  apply Ok_push.
+  apply IHF.
+  inversion HOk.
+  subst.
+  assumption.
+  rewrite dom_union.
+  rewrite union_spec.
+  unfold not; intros.
+  inversion H.
+  apply ok_app_l in HOk.
+  inversion HOk.
+  subst.
+  contradiction.
+  simpl in H0.
+  apply MSetProperties.Dec.F.add_iff in H0.
+  inversion H0.
+  unfold extend in HOk.
+  apply ok_remove in HOk.
+  rewrite <- app_assoc in HOk.
+  apply ok_remove in HOk.
+  simpl in HOk.
+  inversion HOk; subst.
+  simpl in *.
+  apply H6.
+  now apply MSetProperties.Dec.F.add_1.
+  inversion HOk; subst.
+  rewrite dom_union in H6; rewrite union_spec in H6.
+  apply not_or_and in H6.
+  inversion H6.
+  rewrite dom_union in H3; rewrite union_spec in H3; apply not_or_and in H3.
+  inversion H3.
+  contradiction.
+Defined.
+  
+Lemma ok_app_comm : forall {A} (E F : context A), ok (F ++ E) -> ok (E ++ F).
+Proof.
+  intros.
+  generalize dependent H.
+  generalize dependent F.
+  dependent induction E using (@env_ind A).
+  intros.
+  rewrite app_nil_r in H.
+  now simpl.
+  intros.
+  unfold extend in *.
+  rewrite <- app_assoc.
+  apply Ok_push.
+  apply IHE.
+  apply ok_remove in H.
+  assumption.
+  rewrite dom_union.
+  rewrite union_spec.
+  unfold not; intros.
+  inversion H0.
+  apply ok_app_r in H.
+  inversion H; subst.
+  contradiction.
+  rewrite app_assoc in H.
+  apply ok_app_l in H.
+  rewrite <- app_nil_l in H.
+  apply ok_extend_comm in H.
+  rewrite app_nil_l in H.
+  simpl in H.
+  inversion H; subst.
+  contradiction.
+Defined.  
+  
+Definition ok_app_and {A} (E F : context A) (H : ok (E ++ F)) : ok E /\ ok F :=
+  conj (ok_app_l _ _ H) (ok_app_r _ _ H).
+
+Lemma ok_middle_comm :
+  forall {A} (E : context A) F G H, ok (E ++ F ++ G ++ H) -> ok (E ++ G ++ F ++ H).
+Proof.
+  intros.
+  induction E.
+  generalize dependent F.
+  induction H; intros.
+  rewrite app_nil_l in *.
+  rewrite app_nil_r in *.
+  now apply ok_app_comm.
+  rewrite app_nil_l.
+  rewrite app_assoc.
+  apply ok_app_comm.
+  rewrite <- app_comm_cons.
+  destruct a.
+  apply Ok_push.
+  apply ok_app_comm.
+  rewrite <- app_assoc.
+  rewrite app_nil_l in H0.
+  rewrite app_assoc in H0.
+  apply ok_app_comm in H0.
+  rewrite <- app_comm_cons in H0.
+  inversion H0; subst.
+  apply IHlist.
+  rewrite app_nil_l.
+  apply ok_app_comm in H3.
+  now rewrite <- app_assoc in H3.
+  rewrite app_nil_l in H0.
+  rewrite app_assoc in H0.
+  apply ok_app_comm in H0.
+  rewrite <- app_comm_cons in H0.
+  inversion H0; subst.
+  not_in_L v.
+  rewrite dom_union in H2; rewrite union_spec in H2; inversion H2; contradiction.
+  intros.
+  rewrite <- app_comm_cons.
+  destruct a.
+  apply Ok_push.
+  apply IHE.
+  rewrite <- app_comm_cons in H0.
+  inversion H0.
+  assumption.
+  rewrite <- app_comm_cons in H0.
+  inversion H0.
+  subst.
+  not_in_L v.
+  rewrite dom_union in H5; rewrite union_spec in H5; inversion H5.
+  contradiction.
+  rewrite dom_union in H7; rewrite union_spec in H7; inversion H7.
+  contradiction.
+  contradiction.
+Defined.
+
+
+(** Target language **)
+Fixpoint fv (sExp : SExp var) : vars :=
+  match sExp with
+    | STFVar _ v => singleton v
+    | STBVar _ _ => empty
+    | STUnit _ => empty
+    | STLit _ _ => empty
+    | STLam _ _ t => fv t
+    | STLam' _ t => fv t
+    | STApp _ t1 t2 => union (fv t1) (fv t2)
+    | STPair _ t1 t2 => union (fv t1) (fv t2)
+    | STProj1 _ t => fv t
+    | STProj2 _ t => fv t
+  end.
+
+Fixpoint open_rec (k : nat) (u : SExp var) (t : SExp var) {struct t} : SExp var :=
+  match t with
+  | STBVar _ i => if Nat.eqb k i then u else (STBVar _ i)
+  | STFVar _ x => STFVar _ x
+  | STUnit _ => STUnit _
+  | STLit _ x => STLit _ x
+  | STLam _ ty t1 => STLam _ ty (open_rec (S k) u t1)
+  | STLam' _ t1 => STLam' _ (open_rec (S k) u t1)    
+  | STApp _ t1 t2 => STApp _ (open_rec k u t1) (open_rec k u t2)
+  | STPair _ t1 t2 => STPair _ (open_rec k u t1) (open_rec k u t2)
+  | STProj1 _ t => STProj1 _ (open_rec k u t)
+  | STProj2 _ t => STProj2 _ (open_rec k u t)
+  end.
+
+Definition open (t : SExp var) u := open_rec 0 u t.
+
+(* Notation "[ z ~> u ] t" := (subst z u t) (at level 68). *)
+Notation "{ k ~> u } t" := (open_rec k u t) (at level 67).
+Notation "t ^ x" := (open t (STFVar var x)).
+Notation "t ^^ u" := (open t u) (at level 67).
+
+Lemma fv_distr :
+  forall t1 t2 x n, In x (fv (open_rec n t2 t1)) ->
+               In x (union (fv t1) (fv t2)).
+Proof.
+  intros.
+  generalize dependent t2.
+  generalize dependent n.
+  induction t1; intros; simpl in *; rewrite union_spec in *; auto.
+  - destruct (Nat.eqb n0 n); auto. 
+  - rewrite <- union_spec.
+    eapply IHt1.
+    apply H.
+  - apply IHt1 in H.
+    now rewrite union_spec in H.
+  - rewrite union_spec.
+    inversion H.
+    rewrite or_comm at 1.
+    rewrite <- or_assoc.
+    left; rewrite or_comm; rewrite <- union_spec.
+    eapply IHt1_1; apply H0.
+    rewrite or_assoc.
+    right; rewrite <- union_spec.
+    eapply IHt1_2; apply H0.
+  - rewrite union_spec.
+    inversion H.
+    rewrite or_comm at 1.
+    rewrite <- or_assoc.
+    left; rewrite or_comm; rewrite <- union_spec.
+    eapply IHt1_1; apply H0.
+    rewrite or_assoc.
+    right; rewrite <- union_spec.
+    eapply IHt1_2; apply H0.
+  - rewrite <- union_spec.
+    eapply IHt1; apply H.
+  - rewrite <- union_spec.
+    apply (IHt1 _ _ H).
+Defined.
+
+
+Inductive STTerm : SExp var -> Prop :=
+  | STTerm_Var : forall x,
+      STTerm (STFVar _ x)
+  | STTerm_Unit : STTerm (STUnit _)
+  | STTerm_Lit : forall n,
+      STTerm (STLit _ n)
+  | STTerm_Lam : forall L t1 ty,
+      (forall x, not (In x L) -> STTerm (open t1 (STFVar _ x))) ->
+      STTerm (STLam _ ty t1)
+  | STTerm_Lam' : forall L t1,
+      (forall x, not (In x L) -> STTerm (open t1 (STFVar _ x))) ->
+      STTerm (STLam' _ t1)
+  | STTerm_App : forall t1 t2,
+      STTerm t1 -> 
+      STTerm t2 -> 
+      STTerm (STApp _ t1 t2)
+  | STTerm_Pair : forall t1 t2,
+      STTerm t1 ->
+      STTerm t2 ->
+      STTerm (STPair _ t1 t2)
+  | STTerm_Proj1 : forall t,
+      STTerm t ->
+      STTerm (STProj1 _ t)
+  | STTerm_Proj2 : forall t,
+      STTerm t ->
+      STTerm (STProj2 _ t).
+
+Hint Constructors STTerm.
+
+(* Tactics dealing with fresh variables, taken from STLC_Tutorial *)
+
+Ltac gather_vars_with F :=
+  let rec gather V :=
+   (match goal with
+    | H:?S
+      |- _ =>
+          let FH := constr:(F H) in
+          match V with
+          | empty => gather FH
+          | context [FH] => fail 1
+          | _ => gather (union FH V)
+          end
+    | _ => V
+    end)
+  in
+  let L := gather (empty : vars) in
+  eval simpl in L.
+
+Ltac gather_vars :=
+  let A := gather_vars_with (fun x : vars => x) in
+  let B := gather_vars_with (fun x : var => singleton x) in
+  (*let C := gather_vars_with (fun (x : context PTyp) => dom x) in *)
+  let D := gather_vars_with (fun (x : context STyp) => dom x) in
+  (*let E := gather_vars_with (fun x : PExp => fv_source x) in *)
+  let F := gather_vars_with (fun (x : SExp var) => fv x) in
+  constr:(union A (union B (union D F))).
+
+Ltac beautify_fset V :=
+  let rec go Acc E :=
+   (match E with
+    | union ?E1 ?E2 => let Acc1 := go Acc E1 in
+                    go Acc1 E2
+    | empty => Acc
+    | ?E1 => match Acc with
+             | empty => E1
+             | _ => constr:(union Acc E1)
+             end
+    end)
+  in
+  go (empty : vars) V.
+
+Parameter var_fresh : forall L : vars, (sig (A := var) (fun x => not (In x L))).
+  
+Ltac pick_fresh_gen L Y :=
+  let Fr := fresh "Fr" in
+  let L := beautify_fset L in
+  destruct (var_fresh L) as (Y, Fr).
+
+Ltac pick_fresh x :=
+  let L := gather_vars in (pick_fresh_gen L x).
+
+Ltac apply_fresh_base_simple lemma gather :=
+  let L0 := gather in
+  let L := beautify_fset L0 in
+  first
+  [ apply (lemma L) | eapply (lemma L) ].
+
+Ltac intros_fresh x :=
+  first
+  [ let Fr := fresh "Fr" x in
+    intros x Fr
+  | let x2 :=
+     (match goal with
+      | |- ?T -> _ =>
+            match T with
+            | var => fresh "y"
+            | vars => fresh "ys"
+            | list var => fresh "ys"
+            | _ => fresh "y"
+            end
+      end)
+    in
+    let Fr := fresh "Fr" x2 in
+    intros x2 Fr ]. 
+
+Fixpoint fresh (L : vars) (n : nat) (xs : list var) : Prop :=
+  match xs with
+  | nil => match n with
+           | 0 => True
+           | S _ => False
+           end
+  | (x :: xs')%list =>
+      match n with
+      | 0 => False
+      | S n' => (not (In x L)) /\ fresh (union L (singleton x)) n' xs'
+      end
+  end.
+
+Ltac apply_fresh_base lemma gather var_name :=
+  apply_fresh_base_simple lemma gather;
+   try
+    match goal with
+    | |- _ -> not (In _ _) -> _ => intros_fresh var_name
+    | |- _ -> fresh _ _ _ -> _ => intros_fresh var_name
+    end.
+
+Tactic Notation "apply_fresh" constr(T) "as" ident(x) :=
+  apply_fresh_base T gather_vars x.
+
+Lemma open_rec_term_core :forall t j v i u, i <> j ->
+  { j ~> v }t = { i ~> u }({ j ~> v }t) -> t = { i ~> u }t.
+Proof.
+  intro t; induction t; intros; simpl; auto.
+  - simpl in *.
+    case_eq (Nat.eqb i n); intros.
+    case_eq (Nat.eqb j n); intros.
+    exfalso. apply H. apply Nat.eqb_eq in H1.
+    apply Nat.eqb_eq in H2. rewrite H1, H2.
+    reflexivity.
+    rewrite H2 in H0.
+    unfold open_rec in H0.
+    rewrite H1 in H0.
+    assumption.
+    reflexivity.
+  - inversion H0.
+    erewrite <- IHt.
+    reflexivity.
+    apply not_eq_S.
+    apply H.
+    apply H2.
+  - inversion H0.
+    erewrite <- IHt.
+    reflexivity.
+    apply not_eq_S.
+    apply H.
+    apply H2.
+  - inversion H0.
+    erewrite <- IHt1.
+    erewrite <- IHt2.
+    reflexivity.
+    apply H.
+    apply H3.
+    apply H.
+    apply H2.
+  - inversion H0.
+    erewrite <- IHt1.
+    erewrite <- IHt2.
+    reflexivity.
+    apply H. 
+    apply H3.
+    apply H.
+    apply H2.
+  - inversion H0.
+    erewrite <- IHt.
+    reflexivity.
+    apply H.
+    apply H2.
+  - inversion H0.
+    erewrite <- IHt.
+    reflexivity.
+    apply H.
+    apply H2.  
+Defined.
+
+(** Substitution on indices is identity on well-formed terms. *)
+
+Lemma open_rec_term : forall t u,
+  STTerm  t -> forall k, t =  { k ~> u }t.
+Proof.
+  induction 1; intros; simpl; auto.
+  pick_fresh x.
+  rewrite <- open_rec_term_core with (j := 0) (v := STFVar _ x).
+  reflexivity.
+  auto.
+  simpl.
+  unfold open in *.
+  rewrite <- H0.
+  reflexivity.
+  unfold not; intros; apply Fr; rewrite union_spec; rewrite union_spec; left; left.
+  assumption.
+  pick_fresh x.
+  rewrite <- open_rec_term_core with (j := 0) (v := STFVar _ x).
+  reflexivity.
+  auto.
+  simpl.
+  unfold open in *.
+  rewrite <- H0.
+  reflexivity.
+  unfold not; intros; apply Fr; rewrite union_spec; rewrite union_spec; left; left.
+  assumption.
+  rewrite <- IHSTTerm1.
+  rewrite <- IHSTTerm2.
+  reflexivity.
+  rewrite <- IHSTTerm1.
+  rewrite <- IHSTTerm2.
+  reflexivity.
+  rewrite <- IHSTTerm.
+  reflexivity.
+  rewrite <- IHSTTerm.
+  reflexivity.
+Defined.
+
+Hint Resolve open_rec_term.
+
+Lemma open_app_eq : forall x E n F,
+  not (In x (fv E)) ->
+  not (In x (fv F)) ->
+  (open_rec n (STFVar var x) E) = (open_rec n (STFVar var x) F) ->
+  E = F.
+Proof.
+  intros x E.
+  induction E; intros n' F HNotE HNotF HEqOpen.
+  - simpl in *.
+    induction F; try (inversion HEqOpen; auto).
+    destruct (Nat.eqb n' n); auto.
+    exfalso; apply HNotE.
+    apply MSetProperties.Dec.F.singleton_2; inversion H0; reflexivity.
+  - induction F; simpl in *; try (now (destruct (Nat.eqb n' n); inversion HEqOpen)).
+    destruct (Nat.eqb n' n).
+    exfalso; apply HNotF.
+    apply MSetProperties.Dec.F.singleton_2; inversion HEqOpen; reflexivity. 
+    inversion HEqOpen.
+    case_eq (Nat.eqb n' n); intros.
+    case_eq (Nat.eqb n' n0); intros.
+    apply f_equal.
+    apply beq_nat_true in H.
+    apply beq_nat_true in H0.
+    now subst.
+    rewrite H in HEqOpen.
+    rewrite H0 in HEqOpen.
+    inversion HEqOpen.
+    rewrite H in HEqOpen.
+    case_eq (Nat.eqb n' n0); intros;
+    rewrite H0 in HEqOpen; inversion HEqOpen.
+    reflexivity.
+  - induction F; simpl in *; try (now inversion HEqOpen).
+    destruct (Nat.eqb n' n); [ inversion HEqOpen | auto ].
+  - induction F; simpl in *; try (now inversion HEqOpen).
+    destruct (Nat.eqb n' n0); [ inversion HEqOpen | auto ].
+  - induction F; simpl in *; try (now inversion HEqOpen).
+    destruct (Nat.eqb n' n); inversion HEqOpen.
+    inversion HEqOpen.
+    apply f_equal.
+    now apply (IHE (S n')).
+  - induction F; simpl in *; try (now inversion HEqOpen).
+    destruct (Nat.eqb n' n); inversion HEqOpen.
+    inversion HEqOpen.
+    apply f_equal.
+    now apply (IHE (S n')).
+  - induction F; simpl in *; try (now inversion HEqOpen).  
+    destruct (Nat.eqb n' n); inversion HEqOpen.
+    rewrite IHE1 with (F := F1) (n := n'); try not_in_L x.
+    rewrite IHE2 with (F := F2) (n := n'); try not_in_L x.
+    reflexivity.
+    not_in_L x.
+    not_in_L x.
+    now inversion HEqOpen.
+    not_in_L x.
+    not_in_L x.
+    now inversion HEqOpen.
+  - induction F; simpl in *; try (now inversion HEqOpen).  
+    destruct (Nat.eqb n' n); inversion HEqOpen.
+    rewrite IHE1 with (F := F1) (n := n'); try not_in_L x.
+    rewrite IHE2 with (F := F2) (n := n'); try not_in_L x.
+    reflexivity.
+    not_in_L x.
+    not_in_L x.
+    now inversion HEqOpen.
+    not_in_L x.
+    not_in_L x.
+    now inversion HEqOpen.
+  - induction F; simpl in *; try (now inversion HEqOpen).  
+    destruct (Nat.eqb n' n); inversion HEqOpen.
+    apply f_equal.
+    apply IHE with (n := n'); try not_in_L x.
+    now inversion HEqOpen.
+  - induction F; simpl in *; try (now inversion HEqOpen).  
+    destruct (Nat.eqb n' n); inversion HEqOpen.
+    apply f_equal.
+    apply IHE with (n := n'); try not_in_L x.
+    now inversion HEqOpen. 
+Defined.
+
+(* Typing rules *)
+
+(* Typing rules of STLC, inspired by STLC_Tutorial *)
+Inductive has_type_st : (context STyp) -> (SExp var) -> STyp -> Prop :=
+  | STTyVar : forall (Gamma : context STyp) x ty,
+                ok Gamma -> List.In (x,ty) Gamma -> has_type_st Gamma (STFVar _ x) ty
+  | STTyUnit : forall Gamma, ok Gamma -> has_type_st Gamma (STUnit _) STUnitT
+  | STTyLit : forall Gamma x, ok Gamma -> has_type_st Gamma (STLit _ x) STInt       
+  | STTyLam : forall L Gamma t A B,
+                (forall x, not (In x L) -> 
+                      has_type_st (extend x A Gamma) (open t (STFVar _ x)) B) ->
+                has_type_st Gamma (STLam _ A t) (STFun A B)
+  | STTyLam' : forall L Gamma t A B,
+                 (forall x, not (In x L) -> 
+                       has_type_st (extend x A Gamma) (open t (STFVar _ x)) B) ->
+                 has_type_st Gamma (STLam' _ t) (STFun A B)
+  | STTyApp : forall Gamma A B t1 t2, has_type_st Gamma t1 (STFun A B) ->
+                             has_type_st Gamma t2 A -> has_type_st Gamma (STApp _ t1 t2) B
+  | STTyPair : forall Gamma A B t1 t2, has_type_st Gamma t1 A ->
+                              has_type_st Gamma t2 B ->
+                              has_type_st Gamma (STPair _ t1 t2) (STTuple A B)
+  | STTyProj1 : forall Gamma t A B, has_type_st Gamma t (STTuple A B) ->
+                           has_type_st Gamma (STProj1 _ t) A
+  | STTyProj2 : forall Gamma t A B, has_type_st Gamma t (STTuple A B) ->
+                           has_type_st Gamma (STProj2 _ t) B.
+
+Hint Constructors has_type_st.
+
+(* Typing lemmas *)
+
+Lemma typing_weaken : forall G E F t T,
+   has_type_st (E ++ G) t T -> 
+   ok (E ++ F ++ G) ->
+   has_type_st (E ++ F ++ G) t T.
+Proof.
+  intros.
+  generalize dependent H0.
+  remember (E ++ G) as H'.
+  generalize dependent HeqH'.
+  generalize dependent E.
+  dependent induction H; intros; eauto.
+  (* STTyVar *)
+  - subst.
+    apply STTyVar.
+    assumption.
+    apply in_app_or in H0.
+    inversion H0.
+    apply in_or_app; left; assumption.
+    apply in_or_app; right; apply in_or_app; right; assumption.
+  (* STTyLam *)
+  - apply_fresh STTyLam as x.
+    unfold open in *; simpl in *.
+    subst.
+    unfold extend; simpl.
+    rewrite app_comm_cons.
+    apply H0.
+    not_in_L x.
+    unfold extend; simpl; reflexivity.
+    rewrite <- app_comm_cons.
+    apply Ok_push.
+    assumption.
+    not_in_L x.
+    rewrite dom_union in H6.
+    rewrite union_spec in H6.
+    inversion H6; exfalso; [apply H8 | apply H9]; auto.
+  - apply_fresh STTyLam' as x.
+    unfold open in *; simpl in *.
+    subst.
+    unfold extend; simpl.
+    rewrite app_comm_cons.
+    apply H0.
+    not_in_L x.
+    unfold extend; simpl; reflexivity.
+    rewrite <- app_comm_cons.
+    apply Ok_push.
+    assumption.
+    not_in_L x.
+    rewrite dom_union in H6.
+    rewrite union_spec in H6.
+    inversion H6; exfalso; [apply H8 | apply H9]; auto.
+Defined.
+
+Lemma typing_strengthen : forall z U E F t T,
+  not (In z (fv t)) ->
+  has_type_st (E ++ ((z,U) :: nil) ++ F) t T ->
+  has_type_st (E ++ F) t T.
+Proof.
+  intros.
+  remember (E ++ ((z,U) :: nil) ++ F).
+  
+  generalize dependent Heql.
+  generalize dependent E.
+  
+  induction H0; intros; auto.
+  - subst; apply STTyVar.
+    now apply ok_remove in H0.
+    apply in_or_app.
+    repeat apply in_app_or in H1.
+    inversion H1.
+    auto.
+    apply in_app_or in H2.
+    inversion H2.
+    inversion H3.
+    inversion H4.
+    subst.
+    exfalso; apply H; simpl.
+    left; reflexivity.
+    inversion H4.
+    auto.
+  - apply STTyUnit.
+    subst.
+    now apply ok_remove in H0.
+  - apply STTyLit.
+    subst.
+    now apply ok_remove in H0.
+  - subst.
+    apply_fresh STTyLam as x.
+    unfold extend in *; simpl in *.
+    rewrite app_comm_cons.
+    apply H1.
+    not_in_L x.
+    not_in_L z.
+    apply fv_distr in H2.
+    rewrite union_spec in H2.
+    inversion H2.
+    auto.
+    assert (NeqXZ : not (In x (singleton z))) by (not_in_L x).
+    simpl in H3.
+    exfalso; apply NeqXZ.
+    apply MSetProperties.Dec.F.singleton_2.
+    apply MSetProperties.Dec.F.singleton_1 in H3.
+    symmetry; assumption.
+    rewrite app_comm_cons.
+    reflexivity.
+  - subst.
+    apply_fresh STTyLam' as x.
+    unfold extend in *; simpl in *.
+    rewrite app_comm_cons.
+    apply H1.
+    not_in_L x.
+    not_in_L z.
+    apply fv_distr in H2.
+    rewrite union_spec in H2.
+    inversion H2.
+    auto.
+    assert (NeqXZ : not (In x (singleton z))) by (not_in_L x).
+    simpl in H3.
+    exfalso; apply NeqXZ.
+    apply MSetProperties.Dec.F.singleton_2.
+    apply MSetProperties.Dec.F.singleton_1 in H3.
+    symmetry; assumption.
+    rewrite app_comm_cons.
+    reflexivity.
+  - eapply STTyApp.
+    subst.
+    apply IHhas_type_st1; simpl in *; not_in_L z; reflexivity.
+    subst.
+    apply IHhas_type_st2; simpl in *; not_in_L z; reflexivity.
+  - subst.
+    apply STTyPair.
+    apply IHhas_type_st1; simpl in *; not_in_L z; reflexivity.
+    apply IHhas_type_st2; simpl in *; not_in_L z; reflexivity.
+  - subst.
+    eapply STTyProj1.
+    apply IHhas_type_st.
+    not_in_L z.
+    reflexivity.
+  - subst.
+    eapply STTyProj2.
+    apply IHhas_type_st.
+    not_in_L z.
+    reflexivity.
+Defined. 
+
+Lemma has_type_env_comm : forall E F G H T t,
+              has_type_st (E ++ F ++ G ++ H) t T ->
+              has_type_st (E ++ G ++ F ++ H) t T.
+Proof.
+  intros.
+  remember (E ++ F ++ G ++ H).
+  generalize dependent Heql.
+  generalize dependent E.
+  generalize dependent F.
+  generalize dependent G.
+  dependent induction H0; intros; subst; auto.
+  - apply STTyVar.
+    apply ok_app_comm.
+    rewrite <- app_assoc.
+    apply ok_app_comm.
+    rewrite <- app_assoc.
+    apply ok_app_comm.
+    rewrite <- app_assoc.
+    now apply ok_middle_comm.
+    apply in_app_or in H1.
+    inversion H1.
+    apply in_or_app; auto.
+    apply in_or_app; right.
+    apply in_app_or in H2.
+    inversion H2.
+    apply in_or_app.
+    right; apply in_or_app; left.
+    assumption.
+    apply in_app_or in H3.
+    inversion H3.
+    apply in_or_app; auto.
+    apply in_or_app; right; apply in_or_app; auto.
+  - apply STTyUnit.
+    now apply ok_middle_comm.
+  - apply STTyLit.
+    now apply ok_middle_comm.
+  - apply_fresh STTyLam as x.
+    unfold extend.
+    rewrite app_assoc.
+    apply H1.
+    not_in_L x.
+    unfold extend.
+    rewrite <- app_assoc.
+    reflexivity.
+  - apply_fresh STTyLam' as x.
+    unfold extend.
+    rewrite app_assoc.
+    apply H1.
+    not_in_L x.
+    unfold extend.
+    rewrite <- app_assoc.
+    reflexivity.
+  - eapply STTyApp.
+    apply IHhas_type_st1; reflexivity.
+    apply IHhas_type_st2; reflexivity.
+  - eapply STTyProj1; apply IHhas_type_st; reflexivity.
+  - eapply STTyProj2; apply IHhas_type_st; reflexivity.
+Defined.
+    
+Lemma has_type_env_comm_extend : forall Gamma x y v1 v2 E t,
+              has_type_st (extend x v1 (extend y v2 Gamma)) t E ->
+              has_type_st (extend y v2 (extend x v1 Gamma)) t E.
+Proof.
+  unfold extend.
+  intros.
+  rewrite <- app_nil_l with (l := ((x, v1) :: nil) ++ ((y, v2) :: nil) ++ Gamma) in H.
+  apply has_type_env_comm in H.
+  now rewrite app_nil_l in H.
+Defined.  
+
+Lemma typing_weaken_extend : forall t T x v Gamma,
+   has_type_st Gamma t T ->
+   not (M.In x (dom Gamma)) ->                            
+   has_type_st ((x,v) :: Gamma) t T.
+Proof.
+  intros.
+  induction H; eauto.
+  apply STTyVar.
+  apply Ok_push; assumption.
+  apply in_cons; assumption.
+  apply STTyUnit.
+  apply Ok_push; assumption.
+  apply STTyLit.
+  apply Ok_push; assumption.
+  apply_fresh STTyLam as x; cbn.
+  unfold extend in H1.
+  apply has_type_env_comm_extend.
+  apply H1.
+  not_in_L y.
+  not_in_L x.
+  not_in_L y.
+  apply_fresh STTyLam' as x; cbn.
+  unfold extend in H1.
+  apply has_type_env_comm_extend.
+  apply H1.
+  not_in_L y.
+  not_in_L x.
+  not_in_L y.
+Defined.
+
+Lemma typing_ok_env : forall Gamma E ty, has_type_st Gamma E ty -> ok Gamma.
+Proof.
+  intros.
+  induction H; auto;
+  pick_fresh x;
+  assert (Ha: not (In x L)) by not_in_L x;
+  pose (H0 _ Ha) as HInv;
+  inversion HInv; auto.
+Defined.
+  
+Lemma typing_gives_terms : forall Gamma E ty, has_type_st Gamma E ty -> STTerm E.
+Proof.
+  intros.
+  induction H; auto.
+  apply_fresh STTerm_Lam as x.
+  apply H0.
+  not_in_L x.
+  apply_fresh STTerm_Lam' as x.
+  apply H0.
+  not_in_L x.
+Defined.
+
+
+End TLC.

--- a/typediff/without-function/TypeDifference.v
+++ b/typediff/without-function/TypeDifference.v
@@ -1,0 +1,610 @@
+Require Import String.
+Require Import STLC.
+Require Import Coq.Structures.Equalities.
+Require Import Coq.MSets.MSetInterface.
+Require Import Arith.
+Require Import Setoid.
+Require Import Coq.Program.Wf.
+Require Import Coq.omega.Omega.
+Require Import Coq.Program.Equality.
+Require Import CoherenceTop.
+
+
+Module TypeDifferenceModule
+       (Import VarTyp : UsualDecidableTypeFull)
+       (Import set : MSetInterface.S).
+
+Module ST := TLC(VarTyp)(set).
+Import ST.
+
+Module CT := CoherenceTopModule(VarTyp)(set).
+Export CT.
+
+(*
+(* TypSize for Measurement *)
+Fixpoint TypSize (A: PTyp) :nat :=
+  match A with
+  | TopT | PInt => 1
+  | And t1 t2 => TypSize t1 + TypSize t2
+  end.
+
+Lemma TypSize_lt_0 : forall (t:PTyp),
+    0 < TypSize t.
+Proof.
+  intros t. induction t; auto.
+  unfold TypSize.
+  apply (plus_lt_compat 0 (TypSize t1) 0 (TypSize t2)).
+  assumption. assumption.
+Qed.
+
+Lemma TypSize_And_spl : forall (t1 t2:PTyp),
+   TypSize (And t1 t2) = TypSize t1 + TypSize t2.
+Proof.
+  intros.
+  unfold TypSize.
+  auto.
+Qed.
+     
+Lemma TypSize_And_lt : forall (t1 t2: PTyp),
+    TypSize t1 <  TypSize (And t1 t2). 
+Proof.
+  intros. 
+  induction t1.
+  - unfold TypSize.
+    assert (1+0 < 1+ TypSize t2) as H.
+    { apply plus_lt_compat_l. apply TypSize_lt_0. }
+    auto.
+  - rewrite -> TypSize_And_spl. rewrite -> TypSize_And_spl. rewrite -> TypSize_And_spl.
+    rewrite <- Nat.add_assoc. rewrite Nat.add_comm. rewrite (Nat.add_comm (TypSize t1_1)  (TypSize t1_2 + TypSize t2)).
+    apply plus_lt_le_compat.
+    + assert (0 + TypSize t1_2 < TypSize t2 +  TypSize t1_2) as H.
+      { apply plus_lt_le_compat. apply TypSize_lt_0. auto. }
+      auto.
+    + auto.
+  - rewrite TypSize_And_spl.
+     assert (0 + TypSize TopT < TypSize TopT + TypSize t2) as H.
+     {rewrite (Nat.add_comm (TypSize TopT) (TypSize t2)).
+      apply plus_lt_le_compat. apply TypSize_lt_0. auto. }
+     auto.
+Qed.
+*)
+
+Reserved Notation "t1 \ t2 \\ t" (at level 50, left associativity).
+Inductive TypDiff: PTyp -> PTyp -> PTyp -> Prop :=  
+  | DInt_lr:         forall (t: PTyp), PInt \ PInt \\ TopT   
+  (* (A&&B)\te = (A\te) && (B\te) *)                                                        
+  | DandTyp_l:       forall (t t1 t2 r1 r2: PTyp), (Atomic t) -> t1\t\\r1 -> t2\t\\r2 -> (And t1 t2)\t\\(And r1 r2)                                         
+  | DTop_l:          forall (t: PTyp), (Atomic t) -> TopT \ t \\ TopT   
+  (* te -> te\(A&&B) = (te\A)\B *)                                                             
+  | DandTyp_r:       forall (t t1 r1 t2 r2:PTyp), t\t1\\r1 -> r1\t2\\r2 -> t\(And t1 t2)\\r2
+  | DTop_r:          forall (t: PTyp), t \ TopT \\ t 
+where "t1 \ t2 \\ t" := (TypDiff t1 t2 t) : TypExp_Scope.    
+                                                           
+  
+Open Scope TypExp_Scope.
+
+Example case1 :=  (And PInt PInt)\ PInt \\ And TopT TopT.
+Example case2 :=  (And TopT PInt)\ PInt \\ And TopT TopT.
+Example case3 :=  TopT \ (And PInt TopT) \\ TopT.
+
+
+Definition deterministic3 {X: Type} (R: X -> X -> X -> Prop) :=
+  forall x1 x2 y1 y2 : X, R x1 x2 y1 -> R x1 x2 y2 -> y1 = y2.
+
+
+Lemma TypDiff_top_l : forall t t2 : PTyp, TopT \ t \\ t2 -> t2 = TopT.
+Proof.
+  intros. dependent induction H.
+  + auto.
+  + subst. auto.
+  + auto.
+Qed.
+
+Lemma TypDiff_top_l_p : forall t : PTyp, TopT \ t \\ TopT.
+Proof.
+  intros. induction t0.
+  + apply DTop_l. auto.
+  + eapply DandTyp_r. apply IHt0_1. apply IHt0_2.
+  + apply DTop_r.
+Qed.
+    
+Lemma TypDiff_top_r : forall t r : PTyp,  t \ TopT \\ r -> r = t.
+Proof.
+  intros. dependent induction H; subst; auto.
+  inversion H.
+Qed.
+   
+Lemma TypDiff_int_int : forall t : PTyp, PInt \ PInt \\ t -> TopT = t.
+Proof.
+  intros. dependent induction H.
+  + auto.
+Qed.
+
+(* Decidable *)
+Theorem TypDiff_deterministic : deterministic3 TypDiff.
+Proof.
+  unfold deterministic3.
+  intros x1 x2. generalize dependent x1. induction x2.
+  -
+    intros x1. induction x1.
+    + intros.
+    apply TypDiff_int_int in H; subst.
+    apply TypDiff_int_int in H0. auto.
+    + intros.
+    inversion H; subst.
+    inversion H0; subst.
+    apply (IHx1_1 r1 r0) in H4; subst.
+    apply (IHx1_2 r2 r3) in H10; subst.
+    auto.
+    assumption. assumption.
+    +intros.
+    inversion H; subst.
+    inversion H0; subst.
+    auto.
+  - intros x1. induction x1.
+    + intros.
+      inversion H; subst.
+      inversion H0; subst.
+      apply (IHx2_1 PInt r1 r0) in H4; subst.
+      apply (IHx2_2 r0).
+       assumption. assumption. assumption.
+    + intros.
+      inversion H.
+      inversion H3; inversion H8.
+      subst.
+      inversion H0. inversion H3; inversion H10. subst.
+      apply (IHx2_1 (And x1_1 x1_2) r1 r0) in H4; subst.
+      apply (IHx2_2 r0 y2 y1) in H8; subst.
+      auto.
+      assumption. assumption.
+    + intros.
+      apply TypDiff_top_l in H.
+      apply TypDiff_top_l in H0.
+      subst. auto.
+  - intros x1.
+    induction x1; intros; inversion H; inversion H0; auto.
+    + assert (r1 = r0) as G1.
+      { apply IHx1_1. assumption. assumption. }
+      assert (r2 = r3) as G2.
+      { apply IHx1_2. assumption. assumption. }
+      subst. auto.
+    + inversion H3.
+    + inversion H5.
+Qed.
+
+Hint Resolve TypDiff_top_l TypDiff_top_l_p TypDiff_top_r TypDiff_int_int TypDiff_deterministic.
+
+
+Lemma TypDiff_int_l : forall (A D: PTyp),
+    (PInt \ A \\ D) ->  (D=TopT) \/ (D=PInt) .
+Proof.
+  intros. dependent induction H.
+  - auto.
+  - assert (PInt = PInt) as SH by auto;
+    apply IHTypDiff1 in SH;
+    inversion SH; subst.
+    + apply TypDiff_top_l in H0.
+      left. apply H0.
+    + apply IHTypDiff2. auto.
+  - right. auto.
+Qed.
+
+
+Lemma TypDiff_int_l_p : forall (A : PTyp),
+    (PInt \ A \\ TopT) \/ (PInt \ A \\ PInt).
+Proof.
+  intro A.
+  induction A; intros.
+  - left. apply DInt_lr. apply TopT.
+  - intros.
+    destruct IHA1.
+    + left.
+      eapply DandTyp_r.
+      apply H.
+      apply TypDiff_top_l_p.
+    + destruct IHA2; [ left | right];
+        try eapply DandTyp_r; try apply H; try apply H0.
+  - right. apply DTop_r.
+Qed. 
+
+
+Lemma TypDiff_and_l_meg : forall (A B C D E: PTyp),
+    A \ C \\ D -> B \ C \\ E -> And A B \ C \\ And D E.
+Proof.
+  intros A B C. generalize dependent A. generalize dependent B.
+  induction C.
+  - intros. eapply DandTyp_l.
+    auto.
+    assumption. assumption.
+  - intros.
+    inversion H; subst; try inversion H1.
+    inversion H0; subst; try inversion H1.
+    
+    eapply DandTyp_r.
+    eapply IHC1.
+    apply H4. apply H5.
+
+    eapply IHC2.
+    apply H6. apply H8.
+  - intros.
+    inversion H; subst; try inversion H1.
+    inversion H0; subst; try inversion H1.
+    apply DTop_r.
+Qed.
+
+
+(* Reversed *)
+Lemma TypDiff_and_r_spl : forall (C D E F: PTyp),
+    F \ C \\ And D E ->(exists (A B: PTyp), (F = And A B) /\ (A \ C \\ D) /\ (B \ C \\ E)).
+Proof.
+  intros.
+  dependent induction C.
+  - (* C = PInt *)
+    dependent induction F.
+    + (* F = PInt *)
+      exfalso.
+      inversion H.
+    + (* F = And F1 F2 *)
+      auto. exists F1. exists F2.
+      split; auto; try split.
+      * (* F1 \ PInt \\ D *)
+        inversion H; subst; apply H6.
+      * (* F2 \ PInt \\ E *)
+        inversion H; subst; apply H7.
+    + (* F = TopT *)
+      exfalso.
+      inversion H.
+  - (* C = And C1 C2 *)
+    inversion H; subst.
+    + (* F = And t1 t2 *)
+      exists t1. exists t2.
+      inversion H2.
+    + (* \ C1 \ C2 *)
+      apply IHC2 in H5.
+      inversion H5. inversion H0. inversion H1. inversion H4.
+      clear H4 H1 H0 H5. subst.
+      apply IHC1 in H3.
+      inversion H3. inversion H0. inversion H1. inversion H4.
+      clear H4 H1 H0 H3. subst.
+      apply (DandTyp_r _ _ _ C2 D) in H5; auto.
+      apply (DandTyp_r _ _ _ C2 E) in H8; auto.
+      exists x1. exists x2. split; auto.
+  - (* C = TopT *)
+    inversion H; try inversion H2; subst.
+    exists D. exists E. split; auto.
+    split; apply DTop_r.
+Qed.
+
+
+Lemma TypDiff_and_l_and_r : forall (A B C F: PTyp),
+    And A B \ C \\ F -> (exists (D E: PTyp), (F = And D E)).
+Proof.
+  intros A B C. generalize dependent A. generalize dependent B.
+  induction C; intros; try inversion H; subst.
+  - try exists r1; try exists r2; auto.
+  - try exists r1; try exists r2; auto.                            
+  - (* C = And C1 C2 *)
+    auto.
+    apply IHC1 in H3. inversion H3. inversion H0. clear H0 H3. subst.
+    apply IHC2 in H5. inversion H5. inversion H0. clear H0 H5.
+    exists x1. exists x2. auto.
+  - exists r1. exists r2. auto.
+  - exists A. exists B. auto.
+Qed.     
+
+Lemma TypDiff_and_l_spl : forall (A B C F: PTyp),
+    And A B \ C \\ F -> (exists (D E: PTyp), (F = And D E) /\ (A \ C \\ D) /\ (B \ C \\ E)).
+Proof.
+  intros A B C. generalize dependent A. generalize dependent B.
+  induction C; intros.
+  - (* C = PInt *)
+    dependent induction F.
+    + (* F = PInt *)
+      exfalso.
+      inversion H.
+    + (* F = And F1 F2 *)
+      auto. exists F1. exists F2.
+      split; auto; try split.
+      * (* F1 \ PInt \\ D *)
+        inversion H; subst; apply H6.
+      * (* F2 \ PInt \\ E *)
+        inversion H; subst; apply H7.
+    + (* F = TopT *)
+      exfalso.
+      inversion H.
+  - (* C = And C1 C2 *)
+    remember H. clear Heqt0.
+    apply TypDiff_and_l_and_r in H.
+    inversion H; inversion H0; exists x; exists x0.
+    split. auto.
+    split.
+    inversion t0; inversion H4; subst.
+    apply IHC1 in H5.
+    destruct H5. destruct H1. destruct H1. destruct H2.
+    subst.
+    apply IHC2 in H7.
+    destruct H7. destruct H1. destruct H1. destruct H4.
+    subst.
+    apply (DandTyp_r _ _ _ C2 x3) in H2; auto.
+    apply (DandTyp_r _ _ _ C2 x4) in H3; auto.
+    inversion H1. auto.
+    (* repeat for a similar goal *)
+    inversion t0; inversion H4; subst.
+    apply IHC1 in H5.
+    inversion H5. inversion H1. inversion H2. inversion H4.
+    clear H4 H2 H1 H5; subst.
+    apply IHC2 in H7.
+    inversion H7. inversion H1. inversion H2. inversion H4.
+    clear H4 H2 H1 H7.
+    apply (DandTyp_r _ _ _ C2 x3) in H6; auto.
+    apply (DandTyp_r _ _ _ C2 x4) in H9; auto.
+    inversion H3.
+    auto.
+  - (* C = TopT *)
+    inversion H; try inversion H2; subst.
+    exists A. exists B. split; auto.
+    split; apply DTop_r.
+Qed.
+
+
+Theorem TypDiff_comm : forall (C A B D: PTyp), C\(And A B)\\D -> C\(And B A)\\D.
+Proof.
+  intros C. induction C; intros.
+  - remember H as H_p; clear HeqH_p.
+    apply TypDiff_int_l in H.
+    destruct H; subst; inversion H_p; subst.
+    + remember H2 as H2_p; clear HeqH2_p.
+      apply TypDiff_int_l in H2.
+      remember (TypDiff_int_l_p B) as HB; clear HeqHB.
+      destruct HB.
+      (* int -> top -> top *)
+      * eapply DandTyp_r.
+          apply H.
+          apply (TypDiff_top_l_p A).
+      * destruct H2.
+        (* int -> int -> top *)
+        {eapply DandTyp_r.
+        apply H.
+        subst. apply H2_p. }
+        (* contra *)
+        { exfalso.
+          subst.
+          assert (PInt = TopT) as CH.
+          apply (TypDiff_deterministic PInt B PInt TopT).
+          apply H. apply H4.
+          inversion CH. }
+    + remember (TypDiff_int_l_p B) as HB; clear HeqHB.
+      destruct HB.
+      * remember H2 as H2_p; clear HeqH2_p.
+       apply TypDiff_int_l in H2.
+       destruct H2; subst.
+       { apply (TypDiff_top_l B) in H4.
+         inversion H4. }
+       { exfalso.
+          subst.
+          assert (PInt = TopT) as CH.
+          apply (TypDiff_deterministic PInt B PInt TopT).
+          apply H4. apply H.
+          inversion CH. }
+      * remember H2 as H2_p; clear HeqH2_p.
+       apply TypDiff_int_l in H2.
+       destruct H2; subst.
+       { apply (TypDiff_top_l B) in H4.
+         inversion H4. }
+       { eapply DandTyp_r.
+         apply H.
+         apply H2_p. }
+  - apply TypDiff_and_l_spl in H.
+    inversion H; clear H; inversion H0; clear H0; inversion H; subst.
+    inversion H1. clear H H1.
+    apply IHC1 in H0.
+    apply IHC2 in H2.
+    apply (TypDiff_and_l_meg C1 C2 _ x x0) in H0; auto.
+  - (* TopT *)
+    apply TypDiff_top_l in H.
+    rewrite H.
+    apply TypDiff_top_l_p.
+Qed.
+
+Hint Resolve  TypDiff_int_l  TypDiff_int_l_p  TypDiff_and_l_meg  TypDiff_and_r_spl TypDiff_and_l_spl TypDiff_comm.
+
+
+Theorem TypDiff_id : forall A B C D : PTyp,
+    A \ B \\ C -> C \ D \\ A -> C = A.
+Proof.
+  intro A. induction A.
+  - intros.
+    apply (TypDiff_int_l _) in H.
+    destruct H.
+    + exfalso.
+      subst.
+      apply (TypDiff_top_l _) in H0.
+      inversion H0.
+    + assumption.
+  - intros.
+    apply TypDiff_and_l_spl in H.
+    inversion H. inversion H1. inversion H2. inversion H4.
+    clear H4 H2 H1.
+    apply TypDiff_and_r_spl in H0.
+    inversion H0. inversion H1. inversion H2. inversion H7.
+    clear H7 H2 H1. subst.
+    inversion H4. subst. clear H4.
+    apply (IHA1 _ _ D) in H5; auto.
+    apply (IHA2 _ _ D) in H6; auto.
+    rewrite H5. rewrite H6.
+    auto.
+  - (* TopT *)
+    intros.
+    apply TypDiff_top_l in H.
+    auto.
+Qed.
+
+Lemma TypDiff_and_m_spl : forall (C A B : PTyp), C\(And A B)\\C -> (C\A\\C) /\ (C\B\\C).
+Proof.
+  intros.
+  inversion H; inversion H0; inversion H2; subst.
+  remember H3. clear Heqt0.
+  eapply TypDiff_id in H3.
+  rewrite <- H3 in t0.
+  rewrite <- H3 in H5.
+  split; auto.
+  apply H5.
+Qed.
+
+Theorem TypDiff_sym :
+  forall (A B: PTyp), A \ B \\ A ->  B \ A \\ B.
+Proof.
+  intros A.
+  induction A; intros.
+  - induction B.
+    * apply (TypDiff_deterministic PInt PInt TopT PInt) in H.
+      inversion H.
+      apply DInt_lr. apply TopT.
+    * inversion H.
+      subst.
+      apply (TypDiff_int_l B1) in H3.
+      destruct H3; subst.
+      { apply (TypDiff_top_l _) in H5.
+        inversion H5. }
+      { apply IHB2 in H5.
+        inversion H. subst.
+        remember H3 as H3_p; clear HeqH3_p.
+        apply (TypDiff_int_l _) in H3.
+        destruct H3; subst.
+        apply (TypDiff_top_l _) in H6.
+        inversion H6.
+        apply IHB1 in H3_p.
+        eapply TypDiff_and_l_meg.
+        assumption. assumption. }
+    * apply DTop_l.
+      auto.
+  - apply TypDiff_and_l_spl in H.
+    inversion H. inversion H0. inversion H1. inversion H3.
+    clear H3 H1 H0 H.
+    inversion H2.
+    subst.
+    apply IHA1 in H4. apply IHA2 in H5.
+    apply (DandTyp_r _ _ _ x0 B) in H4; auto.
+  - (* TopT *)
+    apply DTop_r.
+Qed.
+
+Lemma TypDiff_int_3 : PInt \ PInt \\ PInt -> False.
+  intros.
+  apply (TypDiff_deterministic PInt PInt PInt TopT) in H.
+  inversion H.
+  apply DInt_lr. apply TopT.
+Qed.
+
+Hint Resolve TypDiff_id TypDiff_and_m_spl TypDiff_sym TypDiff_int_3.
+
+
+Lemma and_not_atomic : forall (A B : PTyp), (Atomic (And A B)) -> False.
+Proof.
+  intros.
+  inversion H.
+Qed.
+
+Lemma TypDiff_and_r : forall A B C D : PTyp, (A \ (And B C) \\ D -> (exists R : PTyp, (A \ B \\ R ) /\ ( R \ C \\ D ))).
+Proof.
+  intros.
+  inversion H.
+  - (* Atomic (And B C) *)
+    apply and_not_atomic in H0.
+    inversion H0.
+  - (* Top \ ... \\ Top *)
+    exists TopT. split; apply TypDiff_top_l_p.
+  - (* \\ r1 \ *)
+    exists r1. split; auto.
+Qed.
+    
+(* Disjointness defined on TypDiff *)
+Definition OrthoD (A B: PTyp) :=
+  A \ B \\ A.
+
+Lemma OrthoD_and : forall ( A B C : PTyp ), OrthoD A (And B C) <-> (OrthoD A B) /\ (OrthoD A C).
+Proof.
+  split.
+  (* -> *)
+  unfold OrthoD. intros.
+  apply TypDiff_and_r in H. destruct H. destruct H.
+  remember H as HB; clear HeqHB.
+  apply (TypDiff_id A B x C)in H ; auto; subst.
+  split; auto.
+  (* <- *)
+  unfold OrthoD. intros.
+  destruct H.
+  apply (DandTyp_r _ _ _ C A) in H; auto.
+Qed.
+
+Lemma OrthoD_sym : forall ( A B : PTyp ), OrthoD A B <-> OrthoD B A.
+Proof.
+  unfold OrthoD.
+  split; apply TypDiff_sym.
+Qed.
+
+Theorem OrthoD_soundness :
+  forall (A B: PTyp), OrthoD A B -> OrthoS A B.
+Proof.
+  intros.
+  induction A.
+  - induction B.
+    + inversion H.
+    + apply OrthoD_and in H. destruct H.
+      apply ortho_sym.
+      apply ortho_and; apply ortho_sym; [apply IHB1 | apply IHB2]; auto.
+    + unfold OrthoS. intros.
+      apply toplike_sub_is_toplike in H1.
+      auto.
+      apply TLTop.
+  - apply OrthoD_sym in H. apply OrthoD_and in H. destruct H.
+    apply ortho_and; [apply IHA1 | apply IHA2]; apply OrthoD_sym; auto.
+  - unfold OrthoS. intros.
+    apply toplike_sub_is_toplike in H0; auto.
+Qed.
+
+Lemma ortho_and_rev : forall (A B C: PTyp),
+    OrthoS (And A B) C -> (OrthoS A C) /\ (OrthoS B C).
+Proof.
+  intros.
+  unfold OrthoS in H.
+  unfold OrthoS; split; intros; specialize (H C0);  apply H.
+  - apply sand2; auto.
+  - auto.
+  - apply sand3; auto.
+  - auto.
+Qed. 
+ 
+Theorem OrthoD_completeness :
+  forall (A B: PTyp), OrthoS A B -> OrthoD A B.
+Proof.
+  intros.
+  induction A.
+  - induction B.
+    + (* PInt PInt *)
+      exfalso.
+      unfold OrthoS in H.
+      remember (H PInt) as HP; clear HeqHP.
+      assert (TopLike PInt -> False) as contra.
+      { intros. inversion H0. }
+      apply contra. apply HP; apply sint.
+    + (* PInt (And B1 B2) *)
+      rewrite -> OrthoD_and.
+      apply ortho_sym in H. apply ortho_and_rev in H. destruct H.
+      split; [apply IHB1 | apply IHB2]; apply ortho_sym; auto.
+    + (* PInt TopT *)
+      unfold OrthoD.
+      auto.
+  - (* (And A1 A2) B *)
+    apply ortho_and_rev in H. destruct H.
+    apply OrthoD_sym. apply OrthoD_and.
+    split; apply OrthoD_sym; [apply IHA1 | apply IHA2]; auto.
+  - (* TopT B *)
+    unfold OrthoD.
+    apply TypDiff_top_l_p.
+Qed.
+    
+End TypeDifferenceModule.
+
+
+


### PR DESCRIPTION
New specification of type disjointness is defined in the original system with Top Type.
Its soundness and completeness (compared to original specification) are proved.

Here two types A B are disjoint iff A \ B => A.
While originally A B are disjoint iff for all C, A<:C -> B<:C -> Toplike C.

Next step functions will be included.

* STLC.v and CoherenceTop.v are based on @jalpuim's work in "withtop/Proofs/SimplerDisjointness/".